### PR TITLE
Center neon run on Bilhuda's signature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "bilhudapramanahasibuan",
       "version": "0.1.0",
       "dependencies": {
+        "@react-three/fiber": "^8.16.12",
         "framer-motion": "^12.6.3",
         "next": "14.1.0",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "three": "^0.171.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -38,6 +40,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -528,6 +539,64 @@
         "node": ">=14"
       }
     },
+    "node_modules/@react-three/fiber": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -572,14 +641,12 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -595,6 +662,21 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.23.tgz",
+      "integrity": "sha512-GPe4AsfOSpqWd3xA/0gwoKod13ChcfV67trvxaW2krUbgb9gxQjnCx8zGshzMl8LSHZlNH5gQ8LNScsDuc7nGQ==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.29.0",
@@ -1189,6 +1271,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1257,6 +1359,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/busboy": {
@@ -1460,7 +1586,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2953,6 +3078,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3461,6 +3606,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/jackspeak": {
@@ -4448,6 +4614,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5121,6 +5327,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.14.tgz",
@@ -5198,6 +5413,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.171.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
+      "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==",
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -5680,6 +5901,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@react-three/fiber": "^8.16.12",
     "framer-motion": "^12.6.3",
     "next": "14.1.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "three": "^0.171.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,460 +3,428 @@
 @tailwind utilities;
 
 :root {
-  --foreground-rgb: 0, 0, 0;
-  --background-rgb: 255, 255, 255;
+  color-scheme: dark;
+  --bg-primary: #030018;
+  --bg-secondary: #060b24;
+  --accent: #6fffe3;
+  --accent-2: #ff6bff;
+  --text-primary: #f6f7ff;
+  --text-muted: rgba(226, 229, 255, 0.62);
+  --glass: rgba(8, 10, 32, 0.58);
+  --glass-strong: rgba(18, 20, 54, 0.82);
 }
 
-/* Dark Mode */
-.dark-mode {
-  --foreground-rgb: 255, 255, 255;
-  --background-rgb: 0, 0, 0;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
-.dark-mode body {
-  color: rgb(var(--foreground-rgb));
-  background: rgb(var(--background-rgb));
+html,
+body {
+  height: 100%;
 }
 
-/* Loading Screen Animation */
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+body {
+  margin: 0;
+  font-family: var(--font-inter, 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  background:
+    radial-gradient(circle at 20% 20%, rgba(111, 255, 240, 0.12), transparent 55%),
+    radial-gradient(circle at 80% 25%, rgba(255, 107, 255, 0.08), transparent 60%),
+    radial-gradient(circle at 50% 85%, rgba(102, 132, 255, 0.1), transparent 60%),
+    var(--bg-primary);
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
 }
 
-@keyframes fadeOut {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
+canvas {
+  display: block;
 }
 
-@keyframes slideUp {
-  from {
-    transform: translateY(100px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-
-.loading-screen {
-  animation: fadeOut 0.5s ease-out forwards;
-  animation-delay: 1.5s;
-}
-
-.loading-text {
-  animation: fadeIn 0.5s ease-out forwards;
-}
-
-/* Page Content Animation */
-.page-content {
-  opacity: 0;
-  animation: fadeIn 0.5s ease-out forwards;
-  animation-delay: 1.5s;
-}
-
-/* Word Morph Animation */
-.word-morph {
-  display: inline-block;
+.game-page {
   position: relative;
-  color: #FFD700;
-  transition: color 0.3s ease;
-  padding: 0 5px;
+  min-height: 100vh;
+  color: var(--text-primary);
 }
 
-.word-morph::before {
-  content: '';
-  position: absolute;
-  width: 100%;
-  height: 1px;
-  bottom: 0;
-  left: 0;
-  background-color: #FFD700;
-  transform-origin: bottom right;
-  transform: scaleX(0);
-  transition: transform 0.5s ease;
-}
-
-.word-morph:hover::before {
-  transform-origin: bottom left;
-  transform: scaleX(1);
-}
-
-/* Cursor and Trails */
-* {
-  cursor: none;
-}
-
-.cursor-dot {
-  width: 5px;
-  height: 5px;
-  background-color: black;
+.canvas-shell {
   position: fixed;
-  border-radius: 50%;
-  pointer-events: none;
-  z-index: 9999;
+  inset: 0;
+  z-index: 0;
 }
 
-.dark-mode .cursor-dot {
-  background-color: white;
-}
-
-.cursor-outline {
-  width: 30px;
-  height: 30px;
-  border: 2px solid black;
-  position: fixed;
-  border-radius: 50%;
-  pointer-events: none;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 10px;
-  color: black;
-  font-weight: bold;
-}
-
-.dark-mode .cursor-outline {
-  border-color: white;
-  color: white;
-}
-
-.cursor-text {
-  font-family: var(--font-space-mono), monospace;
-  text-transform: uppercase;
-  font-size: 8px;
-  font-weight: bold;
-}
-
-.cursor-trail {
-  position: fixed;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background-color: #FFD700;
-  pointer-events: none;
-  z-index: 9998;
-}
-
-/* Inline Tooltip */
-.inline-tooltip {
-  position: fixed;
-  background-color: #000;
-  color: #fff;
-  padding: 6px 10px;
-  border-radius: 4px;
-  font-size: 12px;
-  pointer-events: none;
-  z-index: 100;
-  white-space: nowrap;
-  font-family: var(--font-space-mono), monospace;
-  transform: translateY(-50%);
-}
-
-.dark-mode .inline-tooltip {
-  background-color: #fff;
-  color: #000;
-}
-
-/* Crossword Grid */
-.crossword-grid {
+.hud {
+  position: relative;
+  z-index: 2;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  justify-content: space-between;
+  padding: clamp(1.75rem, 4vw, 3.5rem);
+  pointer-events: none;
 }
 
-.crossword-row {
+.hud-top {
+  max-width: 720px;
+}
+
+.hero-id {
   display: flex;
-  gap: 4px;
+  flex-direction: column;
+  gap: clamp(0.6rem, 2vw, 1rem);
 }
 
-.crossword-cell {
-  width: 30px;
-  height: 30px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+.hero-label {
+  font-family: var(--font-space-mono, 'Space Mono', monospace);
+  letter-spacing: 0.42em;
+  text-transform: uppercase;
+  font-size: clamp(0.75rem, 1.6vw, 0.95rem);
+  color: rgba(226, 229, 255, 0.55);
+}
+
+.hero-lockup {
+  position: relative;
+  padding-left: clamp(0.75rem, 2vw, 1.2rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.25rem, 1.2vw, 0.6rem);
+}
+
+.hero-lockup::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: clamp(0.5rem, 1.8vw, 1.3rem);
+  bottom: clamp(0.5rem, 1.8vw, 1.3rem);
+  width: 4px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(111, 255, 240, 0.8), rgba(255, 107, 255, 0.5));
+  box-shadow: 0 0 22px rgba(79, 255, 230, 0.5);
+}
+
+.hero-subtitle {
+  font-family: var(--font-space-mono, 'Space Mono', monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.42em;
+  font-size: clamp(1.8rem, 5vw, 3.8rem);
+  color: var(--accent);
+  margin: 0;
+  text-shadow: 0 0 45px rgba(111, 255, 240, 0.45);
+}
+
+.hero-name {
+  font-size: clamp(3rem, 8vw, 6rem);
+  line-height: 1.05;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  margin: 0;
+  background: linear-gradient(90deg, #f6f7ff 0%, #6fffe3 45%, #ff6bff 100%);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: none;
+  animation: heroSheen 8s ease-in-out infinite;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  background: var(--glass);
+  border: 1px solid rgba(111, 255, 240, 0.32);
+  font-family: var(--font-space-mono, 'Space Mono', monospace);
+  font-size: 0.82rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  pointer-events: auto;
+  box-shadow: 0 16px 40px rgba(8, 16, 46, 0.45);
+}
+
+.status-chip strong {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.status-message {
+  margin-top: 0.85rem;
+  max-width: 520px;
+  font-size: clamp(1rem, 2.5vw, 1.35rem);
+  line-height: 1.6;
+  color: rgba(240, 242, 255, 0.8);
+}
+
+.score-board {
+  margin-top: clamp(2rem, 4vw, 3rem);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: clamp(1rem, 3vw, 1.8rem);
+  max-width: 760px;
+  pointer-events: auto;
+}
+
+.score-card {
+  background: var(--glass-strong);
+  border-radius: 1.4rem;
+  border: 1px solid rgba(111, 255, 240, 0.18);
+  padding: 1.3rem 1.6rem;
+  box-shadow: 0 24px 55px rgba(6, 10, 38, 0.55);
+  backdrop-filter: blur(22px);
+}
+
+.score-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  color: var(--text-muted);
+  font-family: var(--font-space-mono, 'Space Mono', monospace);
+}
+
+.score-value {
+  margin-top: 0.4rem;
+  font-family: var(--font-space-mono, 'Space Mono', monospace);
+  font-size: clamp(1.6rem, 4vw, 2.75rem);
+  color: var(--text-primary);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.score-value.boosting {
+  color: var(--accent-2);
+  text-shadow: 0 0 22px rgba(255, 107, 255, 0.55);
+}
+
+.controls {
+  margin-top: clamp(2.5rem, 5vw, 3.5rem);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+  pointer-events: auto;
+}
+
+.controls-group {
+  min-width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1.1rem 1.4rem;
+  border-radius: 1.2rem;
+  background: rgba(10, 13, 42, 0.7);
+  border: 1px solid rgba(125, 132, 255, 0.28);
+  box-shadow: 0 18px 50px rgba(4, 6, 24, 0.55);
+}
+
+.controls-title {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  color: var(--text-muted);
+  font-family: var(--font-space-mono, 'Space Mono', monospace);
+}
+
+.controls-keys {
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-weight: bold;
-  font-size: 14px;
+  flex-wrap: wrap;
+  gap: 0.55rem;
 }
 
-.dark-mode .crossword-cell {
-  border-color: rgba(255, 255, 255, 0.1);
+kbd {
+  font-family: var(--font-space-mono, 'Space Mono', monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.7rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(111, 255, 240, 0.3);
+  background: linear-gradient(135deg, rgba(12, 18, 48, 0.9), rgba(28, 40, 96, 0.9));
+  color: var(--text-primary);
+  box-shadow: inset 0 0 14px rgba(111, 255, 240, 0.35);
 }
 
-.crossword-cell.active {
-  background-color: rgba(0, 0, 0, 0.05);
-  color: #000;
+.reset-button {
+  margin-top: clamp(2.2rem, 5vw, 3.4rem);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.8rem 1.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(111, 255, 240, 0.42);
+  background: linear-gradient(120deg, rgba(111, 255, 240, 0.22), rgba(255, 107, 255, 0.22));
+  box-shadow: 0 18px 45px rgba(8, 16, 46, 0.55);
+  font-family: var(--font-space-mono, 'Space Mono', monospace);
+  letter-spacing: 0.26em;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  cursor: pointer;
+  pointer-events: auto;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-.dark-mode .crossword-cell.active {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: #fff;
+.reset-button:hover {
+  transform: translateY(-3px) scale(1.02);
+  box-shadow: 0 20px 70px rgba(111, 255, 240, 0.38);
 }
 
-/* Interactive Text */
-.interactive-text {
-  position: relative;
-  transition: transform 0.3s ease;
-}
-
-/* Mask Reveal Effect */
-@keyframes maskReveal {
-  from {
-    -webkit-mask-position: 0% 0%;
-  }
-  to {
-    -webkit-mask-position: 100% 0%;
-  }
-}
-
-.mask-reveal {
-  -webkit-mask-image: linear-gradient(to right, transparent 0%, #000 50%, transparent 100%);
-  -webkit-mask-size: 200% 100%;
-  -webkit-mask-position: 100% 0%;
-  animation: maskReveal 1s ease-out forwards;
-}
-
-/* Smooth Scrolling */
-html {
-  scroll-behavior: smooth;
-}
-
-/* Base Styles */
-body {
-  color: rgb(var(--foreground-rgb));
-  background: rgb(var(--background-rgb));
-  font-feature-settings: "ss01", "ss02", "cv01", "cv02";
-  -webkit-font-smoothing: antialiased;
-  transition: background-color 0.3s ease, color 0.3s ease;
-}
-
-/* Typography */
-.font-mono {
-  font-family: var(--font-space-mono), monospace;
-}
-
-/* Hover Effects */
-.hover-underline {
-  position: relative;
-  display: inline-block;
-}
-
-.hover-underline::after {
-  content: '';
+.status-bar {
   position: absolute;
-  width: 0;
-  height: 1px;
-  bottom: -2px;
-  left: 0;
-  background-color: currentColor;
-  transition: width 0.3s ease-in-out;
+  top: clamp(1.8rem, 4vw, 3.2rem);
+  right: clamp(1.8rem, 5vw, 3.8rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  align-items: flex-end;
+  pointer-events: none;
+  z-index: 3;
 }
 
-.hover-underline:hover::after {
-  width: 100%;
+.status-bar .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(10, 13, 40, 0.78);
+  font-family: var(--font-space-mono, 'Space Mono', monospace);
+  font-size: 0.78rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  pointer-events: auto;
 }
 
-/* Text Selection */
-::selection {
-  background: #FFD700;
-  color: black;
+.status-bar .chip strong {
+  color: var(--accent);
 }
 
-/* Smooth Transitions */
-a, button {
-  transition: all 0.3s ease-in-out;
+.status-bar .chip.alert {
+  color: #ff9dff;
+  border-color: rgba(255, 157, 255, 0.45);
+  box-shadow: 0 0 22px rgba(255, 157, 255, 0.4);
 }
 
-/* Project Hover Effect */
-.project-item {
-  transition: transform 0.3s ease-in-out;
-  cursor: grab;
-}
-
-.project-item:active {
-  cursor: grabbing;
-}
-
-/* Text Reveal Animation */
-@keyframes revealText {
-  from {
-    clip-path: inset(0 100% 0 0);
-  }
-  to {
-    clip-path: inset(0 0 0 0);
-  }
-}
-
-.reveal-text {
-  animation: revealText 0.8s ease-out forwards;
-}
-
-/* Scroll Progress */
-.scroll-progress {
+.nebula {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 1px;
-  background: rgba(0, 0, 0, 0.1);
-  z-index: 9999;
+  border-radius: 999px;
+  filter: blur(120px);
+  opacity: 0.55;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  animation: drift 20s ease-in-out infinite alternate;
+  z-index: 1;
 }
 
-.dark-mode .scroll-progress {
-  background: rgba(255, 255, 255, 0.1);
+.nebula.one {
+  width: 40vw;
+  height: 40vw;
+  background: radial-gradient(circle, rgba(111, 255, 240, 0.45), rgba(111, 255, 240, 0));
+  top: -12vw;
+  left: -8vw;
 }
 
-.scroll-progress-bar {
-  height: 100%;
-  background: #FFD700;
-  width: var(--scroll-progress, 0%);
-  transition: width 0.1s ease-out;
+.nebula.two {
+  width: 52vw;
+  height: 52vw;
+  background: radial-gradient(circle, rgba(255, 107, 255, 0.35), rgba(255, 107, 255, 0));
+  bottom: -16vw;
+  right: -12vw;
+  animation-duration: 26s;
 }
 
-/* Email Link */
-.email-link {
-  position: relative;
-  display: inline-block;
+.nebula.three {
+  width: 34vw;
+  height: 34vw;
+  background: radial-gradient(circle, rgba(97, 136, 255, 0.3), rgba(97, 136, 255, 0));
+  top: 45%;
+  left: 55%;
+  animation-duration: 30s;
 }
 
-.email-link::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: -2px;
-  width: 100%;
-  height: 1px;
-  background-color: currentColor;
-  transform: scaleX(0);
-  transform-origin: right;
-  transition: transform 0.3s ease;
-}
-
-.email-link:hover::before {
-  transform: scaleX(1);
-  transform-origin: left;
-}
-
-/* Custom Animations */
-@keyframes float {
-  0%, 100% {
-    transform: translateY(0);
+@keyframes heroSheen {
+  0%,
+  20% {
+    background-position: 0% 50%;
   }
   50% {
-    transform: translateY(-10px);
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
   }
 }
 
-.animate-float {
-  animation: float 3s ease-in-out infinite;
+@keyframes drift {
+  from {
+    transform: translate3d(-3%, -2%, 0) scale(1);
+  }
+  to {
+    transform: translate3d(4%, 3%, 0) scale(1.18);
+  }
 }
 
-/* Custom Scrollbar */
-::-webkit-scrollbar {
-  width: 8px;
+@media (max-width: 1024px) {
+  body {
+    overflow-y: auto;
+  }
+
+  .canvas-shell {
+    position: absolute;
+  }
+
+  .hud {
+    padding: 1.8rem;
+  }
+
+  .status-bar {
+    position: static;
+    align-items: flex-start;
+    margin-bottom: 1.8rem;
+  }
 }
 
-::-webkit-scrollbar-track {
-  background: #f1f1f1;
+@media (max-width: 720px) {
+  .hero-subtitle {
+    letter-spacing: 0.45em;
+  }
+
+  .hero-name {
+    letter-spacing: 0.12em;
+  }
+
+  .score-board {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .controls {
+    flex-direction: column;
+  }
+
+  .controls-group {
+    width: 100%;
+  }
+
+  .reset-button {
+    width: 100%;
+    justify-content: center;
+  }
 }
 
-.dark-mode ::-webkit-scrollbar-track {
-  background: #222;
-}
+@media (max-width: 520px) {
+  .hud {
+    padding: 1.6rem 1.25rem 2.5rem;
+  }
 
-::-webkit-scrollbar-thumb {
-  background: #888;
-}
+  .score-board {
+    grid-template-columns: 1fr;
+  }
 
-::-webkit-scrollbar-thumb:hover {
-  background: #555;
+  .status-message {
+    font-size: 1rem;
+  }
 }
-
-.dark-mode ::-webkit-scrollbar-thumb {
-  background: #555;
-}
-
-.dark-mode ::-webkit-scrollbar-thumb:hover {
-  background: #777;
-}
-
-/* Quote Marks */
-.quote-mark {
-  position: relative;
-  display: inline-block;
-}
-
-.quote-mark::before,
-.quote-mark::after {
-  content: '"';
-  position: absolute;
-  font-size: 0.8em;
-  opacity: 0.5;
-}
-
-.quote-mark::before {
-  left: -0.5em;
-}
-
-.quote-mark::after {
-  right: -0.5em;
-}
-
-/* Diagonal Stripes Pattern */
-.diagonal-stripes {
-  background: repeating-linear-gradient(
-    45deg,
-    transparent,
-    transparent 10px,
-    rgba(0, 0, 0, 0.1) 10px,
-    rgba(0, 0, 0, 0.1) 20px
-  );
-}
-
-.dark-mode .diagonal-stripes {
-  background: repeating-linear-gradient(
-    45deg,
-    transparent,
-    transparent 10px,
-    rgba(255, 255, 255, 0.1) 10px,
-    rgba(255, 255, 255, 0.1) 20px
-  );
-}
-
-/* Hazard Pattern */
-.hazard-pattern {
-  background: 
-    linear-gradient(45deg, transparent 45%, #000 45%, #000 55%, transparent 55%),
-    linear-gradient(-45deg, transparent 45%, #000 45%, #000 55%, transparent 55%);
-  background-size: 20px 20px;
-}
-
-.dark-mode .hazard-pattern {
-  background: 
-    linear-gradient(45deg, transparent 45%, #fff 45%, #fff 55%, transparent 55%),
-    linear-gradient(-45deg, transparent 45%, #fff 45%, #fff 55%, transparent 55%);
-  background-size: 20px 20px;
-}
-
-/* Mobile Menu */
-.mobile-menu {
-  @apply fixed top-0 right-0 w-full h-full bg-off-white/90 backdrop-blur-sm z-50;
-  transform: translateX(100%);
-  transition: transform 0.3s ease-in-out;
-}
-
-.mobile-menu.active {
-  transform: translateX(0);
-} 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,61 +2,27 @@ import type { Metadata } from 'next'
 import { Inter, Space_Mono } from 'next/font/google'
 import './globals.css'
 
-const inter = Inter({ subsets: ['latin'] })
-const spaceMono = Space_Mono({ 
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
+const spaceMono = Space_Mono({
   weight: ['400', '700'],
   subsets: ['latin'],
   variable: '--font-space-mono'
 })
 
 export const metadata: Metadata = {
-  title: 'Bilhuda Pramana — UX Designer',
-  description: 'Portfolio of Bilhuda Pramana, UX Designer focused on creating meaningful digital experiences',
+  title: 'Bilhuda Pramana Hasibuan — Neon Signature Run',
+  description:
+    'Pilot a 3D neon arena dedicated to the name Bilhuda Pramana Hasibuan. Drift through glowing letterforms, harvest energy shards, and chase endless combos.'
 }
 
 export default function RootLayout({
-  children,
+  children
 }: {
   children: React.ReactNode
 }) {
   return (
     <html lang="en" className={`${spaceMono.variable}`}>
-      <body className={`${inter.className} bg-off-white text-off-black selection:bg-off-yellow selection:text-off-black`}>
-        <div className="loading-screen fixed inset-0 bg-off-white flex items-center justify-center z-50">
-          <div className="loading-text text-2xl font-mono opacity-0">LOADING</div>
-        </div>
-        <div className="min-h-screen flex flex-col">
-          <header className="fixed top-0 w-full bg-off-white/90 backdrop-blur-sm z-50">
-            <nav className="container mx-auto px-4 py-6">
-              <div className="flex justify-between items-center">
-                <a href="/" className="text-lg font-mono hover:text-off-yellow transition-colors">BP</a>
-                <div className="flex space-x-8 text-sm font-mono">
-                  <a href="#work" className="hover:text-off-yellow transition-colors">WORK</a>
-                  <a href="#about" className="hover:text-off-yellow transition-colors">ABOUT</a>
-                  <a href="#contact" className="hover:text-off-yellow transition-colors">CONTACT</a>
-                </div>
-              </div>
-            </nav>
-          </header>
-          <main className="flex-grow pt-24">
-            {children}
-          </main>
-          <footer className="py-12 border-t border-off-black/10">
-            <div className="container mx-auto px-4">
-              <div className="flex flex-col md:flex-row justify-between items-start md:items-center space-y-4 md:space-y-0">
-                <p className="text-sm font-mono opacity-50">
-                  © 2024 BILHUDA PRAMANA. ALL RIGHTS RESERVED.
-                </p>
-                <div className="flex space-x-4 text-sm font-mono">
-                  <a href="#" className="hover:text-off-yellow transition-colors">INSTAGRAM</a>
-                  <a href="#" className="hover:text-off-yellow transition-colors">TWITTER</a>
-                  <a href="#" className="hover:text-off-yellow transition-colors">LINKEDIN</a>
-                </div>
-              </div>
-            </div>
-          </footer>
-        </div>
-      </body>
+      <body className={`${inter.className} antialiased`}>{children}</body>
     </html>
   )
-} 
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,459 +1,800 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
-import { motion } from 'framer-motion'
+import { Canvas, type ThreeEvent, useFrame, useThree } from '@react-three/fiber'
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import * as THREE from 'three'
+import { TextGeometry } from 'three/examples/jsm/geometries/TextGeometry'
+import { FontLoader, type FontData } from 'three/examples/jsm/loaders/FontLoader'
+import helvetiker from 'three/examples/fonts/helvetiker_regular.typeface.json'
 
-export default function Home() {
-  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
-  const [scrollProgress, setScrollProgress] = useState(0)
-  const [hoveredProject, setHoveredProject] = useState<number | null>(null)
-  const [isDarkMode, setIsDarkMode] = useState(false)
-  const [showAboutModal, setShowAboutModal] = useState(false)
-  const [cursorText, setCursorText] = useState('')
-  const [cursorVariant, setCursorVariant] = useState('default')
-  const [trailPositions, setTrailPositions] = useState<Array<{x: number, y: number}>>([])
-  
-  const constraintsRef = useRef(null)
+const WORLD_BOUNDS = { xz: 18, y: 8 }
+const CLEAR_NAME_RADIUS = 4.2
+
+interface InputState {
+  forward: boolean
+  back: boolean
+  left: boolean
+  right: boolean
+  up: boolean
+  down: boolean
+  boost: boolean
+}
+
+interface OrbState {
+  id: number
+  position: THREE.Vector3
+  active: boolean
+  respawn: number
+  pulseOffset: number
+}
+
+interface CollectPayload {
+  boostActive: boolean
+  speed: number
+}
+
+interface WallHitPayload {
+  impact: number
+}
+
+interface GameWorldProps {
+  onCollect: (payload: CollectPayload) => void
+  onWallHit: (payload: WallHitPayload) => void
+  onBoostChange: (boosting: boolean) => void
+  mouseTarget: React.MutableRefObject<THREE.Vector2>
+}
+
+const COLLECT_MESSAGES = [
+  (combo: number) => `Combo x${combo} — every letter of Bilhuda burns brighter.`,
+  () => 'Shard absorbed. The signature ripples through the neon void.',
+  (combo: number) => `Orbit stabilized. Prime hyper combo x${combo + 1}.`,
+  () => 'Energy anchors synced. Sketch the name across the skyline.'
+]
+
+const formatNumber = (value: number) => value.toLocaleString('en-US')
+
+const formatTime = (totalSeconds: number) => {
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
+}
+
+const randomPosition = () => {
+  const position = new THREE.Vector3(
+    THREE.MathUtils.randFloatSpread(WORLD_BOUNDS.xz * 1.6),
+    THREE.MathUtils.randFloatSpread(WORLD_BOUNDS.y * 1.4),
+    THREE.MathUtils.randFloatSpread(WORLD_BOUNDS.xz * 1.6)
+  )
+
+  const distanceXZ = Math.hypot(position.x, position.z)
+  if (distanceXZ < CLEAR_NAME_RADIUS) {
+    const angle = Math.random() * Math.PI * 2
+    const radius = CLEAR_NAME_RADIUS + Math.random() * 7
+    position.x = Math.cos(angle) * radius
+    position.z = Math.sin(angle) * radius
+  }
+
+  return position
+}
+
+const createOrbs = (count: number): OrbState[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: index,
+    position: randomPosition(),
+    active: true,
+    respawn: 0,
+    pulseOffset: Math.random() * Math.PI * 2
+  }))
+
+const useInputControls = (): InputState => {
+  const [input, setInput] = useState<InputState>({
+    forward: false,
+    back: false,
+    left: false,
+    right: false,
+    up: false,
+    down: false,
+    boost: false
+  })
 
   useEffect(() => {
-    const updateMousePosition = (e: MouseEvent) => {
-      setMousePosition({ x: e.clientX, y: e.clientY })
-      
-      // Add position to trail with a maximum of 10 positions
-      setTrailPositions(prev => {
-        const newPositions = [...prev, { x: e.clientX, y: e.clientY }]
-        if (newPositions.length > 10) {
-          return newPositions.slice(newPositions.length - 10)
+    const updateKey = (code: string, pressed: boolean) => {
+      setInput((prev) => {
+        switch (code) {
+          case 'KeyW':
+          case 'ArrowUp':
+            if (prev.forward === pressed) return prev
+            return { ...prev, forward: pressed }
+          case 'KeyS':
+          case 'ArrowDown':
+            if (prev.back === pressed) return prev
+            return { ...prev, back: pressed }
+          case 'KeyA':
+          case 'ArrowLeft':
+            if (prev.left === pressed) return prev
+            return { ...prev, left: pressed }
+          case 'KeyD':
+          case 'ArrowRight':
+            if (prev.right === pressed) return prev
+            return { ...prev, right: pressed }
+          case 'Space':
+          case 'KeyQ':
+            if (prev.up === pressed) return prev
+            return { ...prev, up: pressed }
+          case 'ControlLeft':
+          case 'ControlRight':
+          case 'KeyE':
+            if (prev.down === pressed) return prev
+            return { ...prev, down: pressed }
+          case 'ShiftLeft':
+          case 'ShiftRight':
+            if (prev.boost === pressed) return prev
+            return { ...prev, boost: pressed }
+          default:
+            return prev
         }
-        return newPositions
       })
     }
 
-    const updateScrollProgress = () => {
-      const scrollPx = document.documentElement.scrollTop
-      const winHeightPx = document.documentElement.scrollHeight - document.documentElement.clientHeight
-      const scrolled = (scrollPx / winHeightPx) * 100
-      setScrollProgress(scrolled)
-    }
-
-    // Keyboard shortcuts
-    const handleKeyPress = (e: KeyboardEvent) => {
-      if (e.key === 'd' && e.ctrlKey) {
-        e.preventDefault()
-        setIsDarkMode(prev => !prev)
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Space'].includes(event.code)) {
+        event.preventDefault()
       }
-      if (e.key === 'a' && e.ctrlKey) {
-        e.preventDefault()
-        setShowAboutModal(prev => !prev)
-      }
+      updateKey(event.code, true)
     }
 
-    window.addEventListener('mousemove', updateMousePosition)
-    window.addEventListener('scroll', updateScrollProgress)
-    window.addEventListener('keydown', handleKeyPress)
-
-    if (isDarkMode) {
-      document.documentElement.classList.add('dark-mode')
-    } else {
-      document.documentElement.classList.remove('dark-mode')
+    const handleKeyUp = (event: KeyboardEvent) => {
+      updateKey(event.code, false)
     }
+
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
 
     return () => {
-      window.removeEventListener('mousemove', updateMousePosition)
-      window.removeEventListener('scroll', updateScrollProgress)
-      window.removeEventListener('keydown', handleKeyPress)
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
     }
-  }, [isDarkMode])
-
-  const projects = [
-    {
-      id: 1,
-      title: "E-commerce Redesign",
-      description: "Improving user flow and conversion rates",
-      role: "Lead UX Designer",
-      year: "2024"
-    },
-    {
-      id: 2,
-      title: "Healthcare App",
-      description: "Making healthcare accessible",
-      role: "UX Research & Design",
-      year: "2023"
-    },
-    {
-      id: 3,
-      title: "Financial Dashboard",
-      description: "Simplifying complex data",
-      role: "Information Architecture",
-      year: "2023"
-    }
-  ]
-
-  const enterButton = () => {
-    setCursorText('View')
-    setCursorVariant('text')
-  }
-
-  const leaveButton = () => {
-    setCursorText('')
-    setCursorVariant('default')
-  }
-
-  const words = ['Designer', 'Thinker', 'Creator', 'Developer', 'UX Expert']
-  const [currentWordIndex, setCurrentWordIndex] = useState(0)
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrentWordIndex(prev => (prev + 1) % words.length)
-    }, 2000)
-    return () => clearInterval(interval)
   }, [])
 
-  const toggleAboutModal = () => {
-    setShowAboutModal(!showAboutModal)
-  }
+  return input
+}
+
+const PlayerShip = ({ boostRef }: { boostRef: React.MutableRefObject<boolean> }) => {
+  const groupRef = useRef<THREE.Group>(null)
+  const glowRef = useRef<THREE.Mesh>(null)
+  const auraRef = useRef<THREE.Mesh>(null)
+
+  useFrame((state, delta) => {
+    if (!groupRef.current) return
+
+    groupRef.current.position.y += Math.sin(state.clock.elapsedTime * 4) * delta * 0.4
+
+    if (glowRef.current) {
+      const material = glowRef.current.material as THREE.MeshStandardMaterial
+      const base = boostRef.current ? 1.7 : 1.2
+      const pulse = 1 + Math.sin((state.clock.elapsedTime + 1.2) * 10) * 0.24
+      glowRef.current.scale.setScalar(base * pulse)
+      material.opacity = boostRef.current ? 0.6 : 0.35
+      material.emissiveIntensity = boostRef.current ? 3.4 : 2.2
+    }
+
+    if (auraRef.current) {
+      const material = auraRef.current.material as THREE.MeshStandardMaterial
+      const pulse = 1 + Math.sin((state.clock.elapsedTime + 0.6) * 5) * 0.15
+      auraRef.current.scale.setScalar(1.6 * pulse)
+      material.opacity = 0.25 + (boostRef.current ? 0.2 : 0.1)
+    }
+  })
+
+  return (
+    <group ref={groupRef}>
+      <mesh castShadow>
+        <coneGeometry args={[0.55, 1.6, 8]} />
+        <meshStandardMaterial
+          color="#7ff7ff"
+          metalness={0.85}
+          roughness={0.25}
+          emissive="#4bf3ff"
+          emissiveIntensity={1.8}
+        />
+      </mesh>
+      <mesh position={[0, -0.45, -0.25]} rotation={[Math.PI / 2, 0, 0]} castShadow>
+        <torusGeometry args={[0.42, 0.08, 14, 32]} />
+        <meshStandardMaterial color="#ffffff" metalness={0.65} roughness={0.25} emissive="#ff6bff" emissiveIntensity={1.4} />
+      </mesh>
+      <mesh ref={glowRef} position={[0, -0.95, -0.4]} transparent>
+        <coneGeometry args={[0.32, 1.5, 16]} />
+        <meshStandardMaterial color="#6fffe3" emissive="#6fffe3" emissiveIntensity={2.6} roughness={0.2} opacity={0.42} transparent />
+      </mesh>
+      <mesh ref={auraRef} position={[0, 0.1, 0]} transparent>
+        <sphereGeometry args={[0.82, 24, 24]} />
+        <meshStandardMaterial color="#ffffff" emissive="#6fffe3" emissiveIntensity={0.4} opacity={0.2} transparent />
+      </mesh>
+    </group>
+  )
+}
+
+const EnergyOrb = ({ data }: { data: OrbState }) => {
+  const coreRef = useRef<THREE.Mesh>(null)
+  const auraRef = useRef<THREE.Mesh>(null)
+
+  useFrame((state, delta) => {
+    if (!coreRef.current) return
+
+    const visible = data.active
+    coreRef.current.visible = visible
+    coreRef.current.position.copy(data.position)
+    coreRef.current.rotation.x += delta * 0.8
+    coreRef.current.rotation.y += delta * 0.6
+
+    const pulse = 1 + Math.sin((state.clock.elapsedTime + data.pulseOffset) * 3) * 0.25
+    coreRef.current.scale.setScalar(visible ? pulse : 0.0001)
+
+    if (auraRef.current) {
+      const material = auraRef.current.material as THREE.MeshBasicMaterial
+      auraRef.current.visible = visible
+      auraRef.current.position.copy(data.position)
+      auraRef.current.scale.setScalar(visible ? pulse * 2.1 : 0.0001)
+      material.opacity = 0.28 + Math.sin((state.clock.elapsedTime + data.pulseOffset) * 2.2) * 0.12
+    }
+  })
 
   return (
     <>
-      {/* Cursor Elements */}
-      <div 
-        className="cursor-dot" 
-        style={{ left: `${mousePosition.x}px`, top: `${mousePosition.y}px` }}
-      />
-      <div 
-        className="cursor-outline" 
-        style={{ 
-          left: `${mousePosition.x - 15}px`, 
-          top: `${mousePosition.y - 15}px`,
-          transform: `scale(${cursorVariant === 'text' ? 1.5 : 1})`
-        }}
-      >
-        {cursorVariant === 'text' && (
-          <span className="cursor-text">{cursorText}</span>
-        )}
-      </div>
-
-      {/* Cursor trails */}
-      {trailPositions.map((pos, i) => (
-        <motion.div
-          key={i}
-          className="cursor-trail"
-          initial={{ scale: 0.8, opacity: 0.8 }}
-          animate={{ 
-            scale: 0,
-            opacity: 0,
-            x: pos.x,
-            y: pos.y
-          }}
-          transition={{ duration: 0.5, delay: i * 0.02 }}
-        />
-      ))}
-
-      <div className="scroll-progress">
-        <div className="scroll-progress-bar" style={{ width: `${scrollProgress}%` }} />
-      </div>
-
-      <div className="page-content space-y-32 py-24">
-        {/* Theme toggle */}
-        <button 
-          className="fixed top-24 right-8 z-40 p-2 bg-off-white dark:bg-off-black border border-off-black dark:border-off-white rounded-full"
-          onClick={() => setIsDarkMode(prev => !prev)}
-          onMouseEnter={() => setCursorText('Theme')}
-          onMouseLeave={leaveButton}
-        >
-          {isDarkMode ? (
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-            </svg>
-          ) : (
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-            </svg>
-          )}
-        </button>
-
-        {/* Hero Section */}
-        <section className="container mx-auto px-4">
-          <div className="max-w-3xl">
-            <p className="text-lg mb-8 font-mono reveal-text">Hello, I am</p>
-            <motion.h1 
-              className="text-6xl md:text-8xl font-bold mb-8 hover:text-off-yellow transition-colors cursor-default reveal-text"
-              whileHover={{ letterSpacing: "2px" }}
-              transition={{ type: "spring", stiffness: 100 }}
-            >
-              BILHUDA PRAMANA
-            </motion.h1>
-            <p className="text-xl md:text-2xl leading-relaxed opacity-70 hover:opacity-100 transition-opacity reveal-text">
-              A UX <span className="word-morph">{words[currentWordIndex]}</span> FOCUSED ON CREATING DIGITAL EXPERIENCES THAT ARE 
-              BOTH FUNCTIONAL AND MEANINGFUL. I BELIEVE IN THE POWER OF 
-              SIMPLICITY AND USER-CENTERED DESIGN.
-            </p>
-          </div>
-        </section>
-
-        {/* Projects Section */}
-        <section id="work" className="container mx-auto px-4">
-          <h2 className="text-2xl font-mono mb-16 reveal-text">Selected Projects</h2>
-          <motion.div className="space-y-8" ref={constraintsRef}>
-            {projects.map((project) => (
-              <motion.div
-                key={project.id}
-                className="group border-b border-off-black/10 dark:border-off-white/10 pb-8 project-item"
-                onMouseEnter={() => {
-                  setHoveredProject(project.id)
-                  setCursorText('Drag')
-                  setCursorVariant('text')
-                }}
-                onMouseLeave={() => {
-                  setHoveredProject(null)
-                  setCursorText('')
-                  setCursorVariant('default')
-                }}
-                drag="x"
-                dragConstraints={constraintsRef}
-                whileDrag={{ scale: 1.05 }}
-                whileHover={{
-                  x: 20,
-                  transition: { duration: 0.3 }
-                }}
-              >
-                <div className="flex items-baseline justify-between group-hover:text-off-yellow transition-colors">
-                  <h3 className="text-4xl font-bold mask-reveal">{project.title}</h3>
-                  <p className="text-lg opacity-50 group-hover:opacity-100 transition-opacity">{project.year}</p>
-                </div>
-                <div className="mt-4 space-y-2 overflow-hidden">
-                  <p className="text-xl transform translate-y-0 group-hover:translate-y-[-8px] transition-transform">
-                    {project.description}
-                  </p>
-                  <p className="text-lg opacity-0 transform translate-y-4 group-hover:translate-y-0 group-hover:opacity-70 transition-all">
-                    {project.role}
-                  </p>
-                </div>
-
-                {/* Tooltip that follows mouse */}
-                {hoveredProject === project.id && (
-                  <div 
-                    className="inline-tooltip"
-                    style={{ 
-                      left: `${mousePosition.x + 20}px`, 
-                      top: `${mousePosition.y + 20}px` 
-                    }}
-                  >
-                    Drag to explore
-                  </div>
-                )}
-              </motion.div>
-            ))}
-          </motion.div>
-        </section>
-
-        {/* About Section */}
-        <section id="about" className="container mx-auto px-4">
-          <div className="max-w-3xl">
-            <h2 
-              className="text-2xl font-mono mb-8 reveal-text cursor-pointer"
-              onClick={toggleAboutModal}
-              onMouseEnter={() => setCursorText('Click')}
-              onMouseLeave={leaveButton}
-            >
-              About
-            </h2>
-            
-            {/* Crossword-style about section */}
-            <div className="crossword-grid mb-8">
-              <div className="crossword-row">
-                <div className="crossword-cell active">D</div>
-                <div className="crossword-cell active">E</div>
-                <div className="crossword-cell active">S</div>
-                <div className="crossword-cell active">I</div>
-                <div className="crossword-cell active">G</div>
-                <div className="crossword-cell active">N</div>
-                <div className="crossword-cell active">E</div>
-                <div className="crossword-cell active">R</div>
-              </div>
-              <div className="crossword-row">
-                <div className="crossword-cell active">E</div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-              </div>
-              <div className="crossword-row">
-                <div className="crossword-cell active">V</div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell active">U</div>
-                <div className="crossword-cell active">X</div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-              </div>
-              <div className="crossword-row">
-                <div className="crossword-cell active">E</div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-              </div>
-              <div className="crossword-row">
-                <div className="crossword-cell active">L</div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell active">C</div>
-                <div className="crossword-cell active">O</div>
-                <div className="crossword-cell active">D</div>
-                <div className="crossword-cell active">E</div>
-              </div>
-              <div className="crossword-row">
-                <div className="crossword-cell active">O</div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-                <div className="crossword-cell"></div>
-              </div>
-              <div className="crossword-row">
-                <div className="crossword-cell active">P</div>
-                <div className="crossword-cell active">A</div>
-                <div className="crossword-cell active">S</div>
-                <div className="crossword-cell active">S</div>
-                <div className="crossword-cell active">I</div>
-                <div className="crossword-cell active">O</div>
-                <div className="crossword-cell active">N</div>
-                <div className="crossword-cell"></div>
-              </div>
-            </div>
-            
-            <div className="space-y-6 text-xl">
-              <motion.p 
-                className="hover:text-off-yellow transition-colors reveal-text interactive-text"
-                whileHover={{ scale: 1.02 }}
-              >
-                I SPECIALIZE IN CREATING INTUITIVE AND ACCESSIBLE DIGITAL EXPERIENCES.
-                MY APPROACH COMBINES USER RESEARCH, ITERATIVE DESIGN, AND A DEEP
-                UNDERSTANDING OF HUMAN BEHAVIOR.
-              </motion.p>
-              <motion.p 
-                className="hover:text-off-yellow transition-colors reveal-text interactive-text"
-                whileHover={{ scale: 1.02 }}
-              >
-                WITH 5+ YEARS OF EXPERIENCE IN UX DESIGN, I'VE WORKED ON PROJECTS
-                RANGING FROM E-COMMERCE PLATFORMS TO HEALTHCARE APPLICATIONS.
-              </motion.p>
-            </div>
-          </div>
-        </section>
-
-        {/* Contact Section */}
-        <section id="contact" className="container mx-auto px-4">
-          <div className="max-w-3xl">
-            <h2 className="text-2xl font-mono mb-8 reveal-text">Let's Connect</h2>
-            <div className="space-y-4">
-              <motion.a 
-                href="mailto:hello@bilhuda.com" 
-                className="block text-2xl hover:text-off-yellow transition-all reveal-text email-link"
-                whileHover={{ x: 20 }}
-                onMouseEnter={enterButton}
-                onMouseLeave={leaveButton}
-              >
-                hello@bilhuda.com
-              </motion.a>
-              <div className="flex space-x-8 text-lg reveal-text">
-                <motion.a 
-                  href="#" 
-                  className="hover-underline hover:text-off-yellow transition-colors"
-                  whileHover={{ y: -5 }}
-                  onMouseEnter={enterButton}
-                  onMouseLeave={leaveButton}
-                >
-                  LinkedIn
-                </motion.a>
-                <motion.a 
-                  href="#" 
-                  className="hover-underline hover:text-off-yellow transition-colors"
-                  whileHover={{ y: -5 }}
-                  onMouseEnter={enterButton}
-                  onMouseLeave={leaveButton}
-                >
-                  Twitter
-                </motion.a>
-                <motion.a 
-                  href="#" 
-                  className="hover-underline hover:text-off-yellow transition-colors"
-                  whileHover={{ y: -5 }}
-                  onMouseEnter={enterButton}
-                  onMouseLeave={leaveButton}
-                >
-                  Read.cv
-                </motion.a>
-              </div>
-            </div>
-          </div>
-        </section>
-      </div>
-
-      {/* About Modal */}
-      {showAboutModal && (
-        <motion.div 
-          className="fixed inset-0 bg-off-black/80 backdrop-blur-md z-50 flex items-center justify-center"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-        >
-          <motion.div 
-            className="bg-off-white dark:bg-off-black text-off-black dark:text-off-white p-8 max-w-2xl rounded-lg"
-            initial={{ y: 50, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ type: "spring", damping: 15 }}
-          >
-            <div className="flex justify-between items-center mb-6">
-              <h2 className="text-2xl font-bold">More About Me</h2>
-              <button 
-                onClick={toggleAboutModal}
-                className="text-2xl"
-                onMouseEnter={() => setCursorText('Close')}
-                onMouseLeave={leaveButton}
-              >
-                ×
-              </button>
-            </div>
-            <div className="space-y-4">
-              <p>
-                I am a UX Designer with a passion for creating digital experiences that are both functional and delightful. 
-                My background in psychology allows me to understand human behavior and apply these insights to design.
-              </p>
-              <p>
-                When I'm not designing, you can find me exploring new technologies, reading design books, or hiking in nature.
-              </p>
-              <div className="mt-6">
-                <h3 className="text-xl font-bold mb-2">Skills</h3>
-                <div className="flex flex-wrap gap-2">
-                  <span className="px-3 py-1 bg-off-yellow text-off-black rounded-full">UX Design</span>
-                  <span className="px-3 py-1 bg-off-yellow text-off-black rounded-full">UI Design</span>
-                  <span className="px-3 py-1 bg-off-yellow text-off-black rounded-full">User Research</span>
-                  <span className="px-3 py-1 bg-off-yellow text-off-black rounded-full">Prototyping</span>
-                  <span className="px-3 py-1 bg-off-yellow text-off-black rounded-full">Figma</span>
-                  <span className="px-3 py-1 bg-off-yellow text-off-black rounded-full">HTML/CSS</span>
-                </div>
-              </div>
-            </div>
-          </motion.div>
-        </motion.div>
-      )}
-
-      {/* Keyboard shortcuts hint */}
-      <div className="fixed bottom-4 right-4 text-xs font-mono opacity-50">
-        Press Ctrl+D for dark mode | Ctrl+A for about modal
-      </div>
+      <mesh ref={coreRef} castShadow>
+        <icosahedronGeometry args={[0.6, 1]} />
+        <meshStandardMaterial color="#7dffeb" emissive="#2cffd3" emissiveIntensity={1.8} roughness={0.2} metalness={0.1} />
+      </mesh>
+      <mesh ref={auraRef} scale={2}>
+        <sphereGeometry args={[1, 32, 32]} />
+        <meshBasicMaterial color="#6fffe3" transparent opacity={0.35} />
+      </mesh>
     </>
   )
-} 
+}
+
+const Starfield = () => {
+  const pointsRef = useRef<THREE.Points>(null)
+  const positions = useMemo(() => {
+    const count = 1800
+    const array = new Float32Array(count * 3)
+    for (let i = 0; i < count; i += 1) {
+      array[i * 3] = THREE.MathUtils.randFloatSpread(160)
+      array[i * 3 + 1] = THREE.MathUtils.randFloatSpread(160)
+      array[i * 3 + 2] = THREE.MathUtils.randFloatSpread(160)
+    }
+    return array
+  }, [])
+
+  useFrame((_, delta) => {
+    if (!pointsRef.current) return
+    pointsRef.current.rotation.y += delta * 0.015
+    pointsRef.current.rotation.x += delta * 0.006
+  })
+
+  return (
+    <points ref={pointsRef} frustumCulled={false}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" array={positions} count={positions.length / 3} itemSize={3} />
+      </bufferGeometry>
+      <pointsMaterial size={0.35} color="#6fffe3" sizeAttenuation depthWrite={false} transparent opacity={0.6} />
+    </points>
+  )
+}
+
+const NeonGrid = () => {
+  const helper = useMemo(() => {
+    const grid = new THREE.GridHelper(160, 80, new THREE.Color('#2cffec'), new THREE.Color('#143264'))
+    const materials = grid.material
+    if (Array.isArray(materials)) {
+      materials.forEach((material) => {
+        material.transparent = true
+        material.opacity = 0.2
+      })
+    } else {
+      materials.transparent = true
+      materials.opacity = 0.2
+    }
+    return grid
+  }, [])
+
+  useEffect(() => () => helper.dispose(), [helper])
+
+  return <primitive object={helper} position={[0, -9, 0]} />
+}
+
+type FloatingRingProps = {
+  radius: number
+  position: [number, number, number]
+  speed: number
+  color: string
+}
+
+const FloatingRing = ({ radius, position, speed, color }: FloatingRingProps) => {
+  const ringRef = useRef<THREE.Mesh>(null)
+
+  useFrame((state, delta) => {
+    if (!ringRef.current) return
+    ringRef.current.rotation.x += delta * speed * 0.5
+    ringRef.current.rotation.z += delta * speed * 0.4
+    ringRef.current.position.y = position[1] + Math.sin(state.clock.elapsedTime * speed) * 0.6
+  })
+
+  return (
+    <mesh ref={ringRef} position={position} rotation={[Math.PI / 2, 0, 0]}
+      receiveShadow>
+      <torusGeometry args={[radius, 0.12, 16, 64]} />
+      <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.9} roughness={0.3} metalness={0.45} />
+    </mesh>
+  )
+}
+
+const FloatingRings = () => {
+  const rings = useMemo<FloatingRingProps[]>(
+    () => [
+      { radius: 6, position: [0, -2.4, -4], speed: 0.6, color: '#4b82ff' },
+      { radius: 9, position: [-6, 1.8, 3], speed: 0.4, color: '#ff6bff' },
+      { radius: 4.5, position: [6, 2.2, -2], speed: 0.75, color: '#6fffe3' }
+    ],
+    []
+  )
+
+  return (
+    <group>
+      {rings.map((ring) => (
+        <FloatingRing key={`${ring.radius}-${ring.position.join('-')}`} {...ring} />
+      ))}
+    </group>
+  )
+}
+
+const NameGlyphs = () => {
+  const groupRef = useRef<THREE.Group>(null)
+  const haloRef = useRef<THREE.Mesh>(null)
+
+  const font = useMemo(() => {
+    const loader = new FontLoader()
+    return loader.parse(helvetiker as FontData)
+  }, [])
+
+  const bilhudaGeometry = useMemo(() => {
+    const geometry = new TextGeometry('BILHUDA', {
+      font,
+      size: 2.6,
+      height: 0.6,
+      curveSegments: 16,
+      bevelEnabled: true,
+      bevelThickness: 0.12,
+      bevelSize: 0.08,
+      bevelSegments: 5
+    })
+    geometry.center()
+    return geometry
+  }, [font])
+
+  const pramanaGeometry = useMemo(() => {
+    const geometry = new TextGeometry('PRAMANA HASIBUAN', {
+      font,
+      size: 1.1,
+      height: 0.38,
+      curveSegments: 16,
+      bevelEnabled: true,
+      bevelThickness: 0.08,
+      bevelSize: 0.05,
+      bevelSegments: 4
+    })
+    geometry.center()
+    return geometry
+  }, [font])
+
+  useEffect(
+    () => () => {
+      bilhudaGeometry.dispose()
+      pramanaGeometry.dispose()
+    },
+    [bilhudaGeometry, pramanaGeometry]
+  )
+
+  useFrame((state) => {
+    if (groupRef.current) {
+      const time = state.clock.elapsedTime
+      groupRef.current.rotation.y = Math.sin(time * 0.25) * 0.35
+      groupRef.current.rotation.x = Math.sin(time * 0.18) * 0.12
+      groupRef.current.position.y = Math.sin(time * 0.9) * 0.6
+    }
+
+    if (haloRef.current) {
+      const material = haloRef.current.material as THREE.MeshBasicMaterial
+      const time = state.clock.elapsedTime
+      const pulse = 1 + Math.sin(time * 0.6) * 0.08
+      haloRef.current.scale.setScalar(pulse)
+      material.opacity = 0.3 + Math.sin(time * 1.5) * 0.12
+    }
+  })
+
+  return (
+    <group ref={groupRef} position={[0, 0.4, 0]}>
+      <mesh geometry={bilhudaGeometry} position={[0, 1.6, 0]} castShadow>
+        <meshStandardMaterial
+          color="#bff6ff"
+          emissive="#40f8ff"
+          emissiveIntensity={2.6}
+          metalness={0.65}
+          roughness={0.32}
+        />
+      </mesh>
+      <mesh geometry={pramanaGeometry} position={[0, -0.6, 0]} castShadow>
+        <meshStandardMaterial
+          color="#ffd8ff"
+          emissive="#ff6bff"
+          emissiveIntensity={1.9}
+          metalness={0.58}
+          roughness={0.35}
+        />
+      </mesh>
+      <mesh ref={haloRef} rotation={[-Math.PI / 2, 0, 0]} position={[0, -2.2, 0]}>
+        <ringGeometry args={[3.4, 3.9, 64]} />
+        <meshBasicMaterial color="#6fffe3" transparent opacity={0.35} />
+      </mesh>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -2.2, 0]}>
+        <ringGeometry args={[2.7, 2.95, 64]} />
+        <meshBasicMaterial color="#ff6bff" transparent opacity={0.28} />
+      </mesh>
+    </group>
+  )
+}
+
+const GameWorld = ({ onCollect, onWallHit, onBoostChange, mouseTarget }: GameWorldProps) => {
+  const shipRef = useRef<THREE.Group>(null)
+  const boostRef = useRef(false)
+  const boostState = useRef(false)
+  const velocityRef = useRef(new THREE.Vector3())
+  const wallCooldown = useRef(0)
+  const input = useInputControls()
+  const { camera } = useThree()
+  const orbsRef = useRef<OrbState[]>(createOrbs(42))
+  const [, forceRerender] = useState(0)
+
+  useFrame((state, delta) => {
+    const ship = shipRef.current
+    if (!ship) return
+
+    const movement = new THREE.Vector3(
+      (input.right ? 1 : 0) - (input.left ? 1 : 0),
+      (input.up ? 1 : 0) - (input.down ? 1 : 0),
+      (input.forward ? -1 : 0) + (input.back ? 1 : 0)
+    )
+
+    if (movement.lengthSq() > 0) {
+      movement.normalize()
+    }
+
+    const boost = input.boost
+    boostRef.current = boost
+    if (boost !== boostState.current) {
+      boostState.current = boost
+      onBoostChange(boost)
+    }
+
+    const acceleration = boost ? 42 : 28
+    velocityRef.current.addScaledVector(movement, acceleration * delta)
+
+    const friction = boost ? 0.9 : 0.82
+    velocityRef.current.multiplyScalar(friction)
+
+    const maxVelocity = boost ? 18 : 12
+    if (velocityRef.current.length() > maxVelocity) {
+      velocityRef.current.setLength(maxVelocity)
+    }
+
+    ship.position.addScaledVector(velocityRef.current, delta)
+    ship.position.y += Math.sin(state.clock.elapsedTime * 0.6) * delta * 0.4
+
+    const bounds = WORLD_BOUNDS
+    let bounced = false
+
+    if (ship.position.x > bounds.xz) {
+      ship.position.x = bounds.xz
+      velocityRef.current.x *= -0.48
+      bounced = true
+    } else if (ship.position.x < -bounds.xz) {
+      ship.position.x = -bounds.xz
+      velocityRef.current.x *= -0.48
+      bounced = true
+    }
+
+    if (ship.position.z > bounds.xz) {
+      ship.position.z = bounds.xz
+      velocityRef.current.z *= -0.48
+      bounced = true
+    } else if (ship.position.z < -bounds.xz) {
+      ship.position.z = -bounds.xz
+      velocityRef.current.z *= -0.48
+      bounced = true
+    }
+
+    if (ship.position.y > bounds.y) {
+      ship.position.y = bounds.y
+      velocityRef.current.y *= -0.38
+      bounced = true
+    } else if (ship.position.y < -bounds.y) {
+      ship.position.y = -bounds.y
+      velocityRef.current.y *= -0.38
+      bounced = true
+    }
+
+    if (bounced) {
+      wallCooldown.current -= delta
+      if (wallCooldown.current <= 0) {
+        wallCooldown.current = 0.45
+        onWallHit({ impact: velocityRef.current.length() })
+      }
+    } else {
+      wallCooldown.current = Math.max(0, wallCooldown.current - delta)
+    }
+
+    const look = mouseTarget.current
+    ship.rotation.x = THREE.MathUtils.lerp(ship.rotation.x, look.y * 0.35 - velocityRef.current.z * 0.04, 0.08)
+    ship.rotation.z = THREE.MathUtils.lerp(ship.rotation.z, -look.x * 0.45 - velocityRef.current.x * 0.05, 0.08)
+    ship.rotation.y = THREE.MathUtils.lerp(ship.rotation.y, look.x * 0.25, 0.08)
+
+    const camTarget = new THREE.Vector3(ship.position.x * 0.42, ship.position.y + 5.4, ship.position.z + 14)
+    camera.position.lerp(camTarget, 0.06)
+    camera.lookAt(ship.position)
+
+    let changed = false
+    const playerPosition = ship.position
+
+    orbsRef.current.forEach((orb) => {
+      if (orb.active) {
+        if (orb.position.distanceTo(playerPosition) < 1.6) {
+          orb.active = false
+          orb.respawn = 1.4 + Math.random() * 1.8
+          changed = true
+          onCollect({ boostActive: boostRef.current, speed: velocityRef.current.length() })
+        }
+      } else {
+        orb.respawn -= delta
+        if (orb.respawn <= 0) {
+          orb.active = true
+          orb.position.copy(randomPosition())
+          orb.respawn = 0
+          changed = true
+        }
+      }
+    })
+
+    if (changed) {
+      forceRerender((value) => value + 1)
+    }
+  })
+
+  return (
+    <>
+      <group ref={shipRef} position={[0, 0, 8]}>
+        <PlayerShip boostRef={boostRef} />
+      </group>
+      {orbsRef.current.map((orb) => (
+        <EnergyOrb key={orb.id} data={orb} />
+      ))}
+      <NameGlyphs />
+      <FloatingRings />
+      <NeonGrid />
+      <Starfield />
+    </>
+  )
+}
+
+const HomePage = () => {
+  const [score, setScore] = useState(0)
+  const [combo, setCombo] = useState(1)
+  const [maxCombo, setMaxCombo] = useState(1)
+  const [seconds, setSeconds] = useState(0)
+  const [statusMessage, setStatusMessage] = useState('Ignite the Bilhuda monogram. Sweep the arena for radiant shards.')
+  const [isBoosting, setIsBoosting] = useState(false)
+  const [highScore, setHighScore] = useState(0)
+  const [gameKey, setGameKey] = useState(0)
+  const timerRef = useRef<NodeJS.Timeout | null>(null)
+  const mouseTarget = useRef(new THREE.Vector2(0, 0))
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const stored = window.localStorage.getItem('bp-neon-highscore')
+    if (stored) {
+      const parsed = Number.parseInt(stored, 10)
+      if (!Number.isNaN(parsed)) {
+        setHighScore(parsed)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current)
+    }
+    timerRef.current = setInterval(() => {
+      setSeconds((prev) => prev + 1)
+    }, 1000)
+    return () => {
+      if (timerRef.current) {
+        clearInterval(timerRef.current)
+      }
+    }
+  }, [gameKey])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem('bp-neon-highscore', String(highScore))
+  }, [highScore])
+
+  const handleCollect = useCallback(
+    ({ boostActive, speed }: CollectPayload) => {
+      const nextCombo = Math.min(combo + 1, 20)
+      const velocityBonus = Math.round(speed * 14)
+      const baseScore = boostActive ? 220 : 150
+
+      setScore((prev) => {
+        const updated = prev + baseScore * combo + velocityBonus
+        setHighScore((current) => (updated > current ? updated : current))
+        return updated
+      })
+
+      setCombo(nextCombo)
+      setMaxCombo((prev) => (nextCombo > prev ? nextCombo : prev))
+
+      const generator = COLLECT_MESSAGES[Math.floor(Math.random() * COLLECT_MESSAGES.length)]
+      setStatusMessage(generator(nextCombo))
+    },
+    [combo]
+  )
+
+  const handleWallHit = useCallback(
+    ({ impact }: WallHitPayload) => {
+      if (combo > 1) {
+        setStatusMessage(`Wall scrape! Combo reset — impact ${impact.toFixed(1)}g.`)
+      } else {
+        setStatusMessage('Breathe, align, and re-thread the signature trail.')
+      }
+      setCombo(1)
+    },
+    [combo]
+  )
+
+  const handleBoostChange = useCallback((boosting: boolean) => {
+    setIsBoosting(boosting)
+    if (boosting) {
+      setStatusMessage('Signature boost engaged — carve the Bilhuda trail!')
+    }
+  }, [])
+
+  const handlePointerMove = useCallback((event: ThreeEvent<PointerEvent>) => {
+    const bounds = event.currentTarget.getBoundingClientRect()
+    const x = (event.clientX - bounds.left) / bounds.width
+    const y = (event.clientY - bounds.top) / bounds.height
+    mouseTarget.current.set(x * 2 - 1, -(y * 2 - 1))
+  }, [])
+
+  const handleReset = useCallback(() => {
+    setGameKey((value) => value + 1)
+    setScore(0)
+    setCombo(1)
+    setMaxCombo(1)
+    setSeconds(0)
+    setStatusMessage('Fresh run online. Repaint the Bilhuda glyph across the skyline.')
+    setIsBoosting(false)
+  }, [])
+
+  return (
+    <main className="game-page">
+      <div className="canvas-shell">
+        <Canvas
+          key={gameKey}
+          shadows
+          camera={{ fov: 55, position: [0, 6, 18] }}
+          dpr={[1, 2]}
+          onPointerMove={handlePointerMove}
+        >
+          <color attach="background" args={["#020014"]} />
+          <fog attach="fog" args={["#020014", 25, 90]} />
+          <ambientLight intensity={0.4} />
+          <pointLight position={[0, 8, 10]} intensity={2.1} color="#6fffe3" castShadow />
+          <pointLight position={[-12, -6, -14]} intensity={1.4} color="#ff6bff" />
+          <Suspense fallback={null}>
+            <GameWorld
+              onCollect={handleCollect}
+              onWallHit={handleWallHit}
+              onBoostChange={handleBoostChange}
+              mouseTarget={mouseTarget}
+            />
+          </Suspense>
+        </Canvas>
+      </div>
+      <div className="hud">
+        <div className="hud-top">
+          <div className="hero-id">
+            <span className="hero-label">Callsign</span>
+            <div className="hero-lockup">
+              <p className="hero-subtitle">Bilhuda</p>
+              <h1 className="hero-name">Pramana Hasibuan</h1>
+            </div>
+          </div>
+          <div className="status-chip">
+            <span>Mode</span>
+            <strong>{combo > 1 ? `Combo x${combo}` : 'Freeflight'}</strong>
+          </div>
+          <p className="status-message">{statusMessage}</p>
+          <div className="score-board">
+            <div className="score-card">
+              <span className="score-label">Score</span>
+              <span className={`score-value${isBoosting ? ' boosting' : ''}`}>{formatNumber(score)}</span>
+            </div>
+            <div className="score-card">
+              <span className="score-label">Time</span>
+              <span className="score-value">{formatTime(seconds)}</span>
+            </div>
+            <div className="score-card">
+              <span className="score-label">Best Combo</span>
+              <span className="score-value">x{maxCombo}</span>
+            </div>
+            <div className="score-card">
+              <span className="score-label">High Score</span>
+              <span className="score-value">{formatNumber(highScore)}</span>
+            </div>
+          </div>
+          <button className="reset-button" type="button" onClick={handleReset}>
+            Reboot Signature
+          </button>
+        </div>
+        <div className="controls">
+          <div className="controls-group">
+            <span className="controls-title">Drift</span>
+            <div className="controls-keys">
+              <kbd>W</kbd>
+              <kbd>A</kbd>
+              <kbd>S</kbd>
+              <kbd>D</kbd>
+            </div>
+            <div className="controls-keys">
+              <kbd>↑</kbd>
+              <kbd>←</kbd>
+              <kbd>↓</kbd>
+              <kbd>→</kbd>
+            </div>
+          </div>
+          <div className="controls-group">
+            <span className="controls-title">Rise / Dive</span>
+            <div className="controls-keys">
+              <kbd>Space</kbd>
+              <kbd>Ctrl</kbd>
+            </div>
+          </div>
+          <div className="controls-group">
+            <span className="controls-title">Boost</span>
+            <div className="controls-keys">
+              <kbd>Shift</kbd>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="status-bar">
+        <div className="chip">
+          <span>Session</span>
+          <strong>{formatTime(seconds)}</strong>
+        </div>
+        <div className={`chip${isBoosting ? ' alert' : ''}`}>
+          <span>Thruster</span>
+          <strong>{isBoosting ? 'Boost' : 'Cruise'}</strong>
+        </div>
+        <div className={`chip${combo >= 5 ? ' alert' : ''}`}>
+          <span>Combo</span>
+          <strong>x{combo}</strong>
+        </div>
+      </div>
+      <div className="nebula one" />
+      <div className="nebula two" />
+      <div className="nebula three" />
+    </main>
+  )
+}
+
+export default HomePage


### PR DESCRIPTION
## Summary
- add an animated NameGlyphs centerpiece and keep shard spawns away from the signature space to spotlight the Bilhuda monogram
- retune HUD copy and controls to frame the experience as a name-driven freeflight run with a rebootable signature state
- refresh hero styling and metadata to present a neon signature run instead of a generic portfolio playground

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d52d1c68a08323b06e40d3b2e3eced