### PR TITLE
Revamp site into neon gameverse

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,36 +3,40 @@
 @tailwind utilities;
 
 :root {
-  --foreground-rgb: 15, 23, 42;
-  --background-rgb: 245, 246, 248;
-  --surface: rgba(255, 255, 255, 0.78);
-  --surface-dark: rgba(14, 14, 18, 0.82);
-  --outline: rgba(15, 23, 42, 0.08);
-  --outline-strong: rgba(15, 23, 42, 0.18);
-  --accent: #ffd75c;
-  --accent-soft: rgba(255, 215, 92, 0.35);
-  --accent-2: #5ac8fa;
-  --muted: rgba(15, 23, 42, 0.62);
-  --shadow: rgba(15, 23, 42, 0.18);
+  --foreground-rgb: 226, 241, 255;
+  --background-rgb: 4, 6, 24;
+  --surface: rgba(18, 22, 52, 0.75);
+  --surface-dark: rgba(6, 9, 28, 0.82);
+  --outline: rgba(83, 180, 255, 0.14);
+  --outline-strong: rgba(83, 180, 255, 0.28);
+  --accent: #ff47d8;
+  --accent-soft: rgba(255, 71, 216, 0.32);
+  --accent-2: #29f0ff;
+  --muted: rgba(182, 205, 255, 0.72);
+  --shadow: rgba(3, 2, 20, 0.55);
 }
 
 .dark-mode {
-  --foreground-rgb: 244, 245, 255;
-  --background-rgb: 5, 6, 10;
-  --surface: rgba(20, 20, 22, 0.78);
-  --surface-dark: rgba(10, 10, 12, 0.82);
-  --outline: rgba(244, 245, 255, 0.08);
-  --outline-strong: rgba(244, 245, 255, 0.16);
-  --muted: rgba(240, 241, 250, 0.6);
-  --shadow: rgba(0, 0, 0, 0.45);
+  --foreground-rgb: 21, 26, 51;
+  --background-rgb: 244, 247, 255;
+  --surface: rgba(255, 255, 255, 0.82);
+  --surface-dark: rgba(230, 235, 255, 0.88);
+  --outline: rgba(21, 26, 51, 0.1);
+  --outline-strong: rgba(21, 26, 51, 0.22);
+  --muted: rgba(69, 86, 129, 0.7);
+  --shadow: rgba(58, 89, 200, 0.18);
 }
 
 body {
   color: rgb(var(--foreground-rgb));
-  background: rgb(var(--background-rgb));
+  background:
+    radial-gradient(120% 120% at 50% -10%, rgba(102, 44, 255, 0.35), transparent 60%),
+    radial-gradient(100% 120% at 5% 80%, rgba(41, 240, 255, 0.22), transparent 70%),
+    radial-gradient(120% 120% at 95% 90%, rgba(255, 71, 216, 0.2), transparent 75%),
+    rgb(var(--background-rgb));
   font-feature-settings: 'ss01', 'ss02', 'cv01', 'cv02';
   -webkit-font-smoothing: antialiased;
-  transition: background-color 0.4s ease, color 0.4s ease;
+  transition: background 0.6s ease, color 0.4s ease;
   min-height: 100vh;
 }
 
@@ -142,11 +146,11 @@ button {
   width: 140vw;
   height: 140vh;
   background:
-    radial-gradient(circle at 20% 20%, rgba(255, 214, 94, 0.55), transparent 60%),
-    radial-gradient(circle at 75% 25%, rgba(120, 208, 255, 0.45), transparent 65%),
-    radial-gradient(circle at 50% 70%, rgba(255, 140, 222, 0.35), transparent 65%);
-  filter: blur(90px);
-  opacity: 0.7;
+    radial-gradient(circle at 20% 20%, rgba(255, 71, 216, 0.55), transparent 60%),
+    radial-gradient(circle at 75% 25%, rgba(41, 240, 255, 0.45), transparent 65%),
+    radial-gradient(circle at 50% 70%, rgba(111, 52, 255, 0.38), transparent 65%);
+  filter: blur(100px);
+  opacity: 0.75;
   pointer-events: none;
   mix-blend-mode: screen;
   z-index: 0;
@@ -195,16 +199,17 @@ button {
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
-  background: var(--surface);
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  box-shadow: 0 24px 60px var(--shadow);
+  background: linear-gradient(135deg, rgba(25, 32, 82, 0.92), rgba(15, 18, 48, 0.92));
+  border: 1px solid rgba(83, 180, 255, 0.22);
+  box-shadow: 0 24px 70px rgba(4, 6, 24, 0.55);
   backdrop-filter: blur(24px);
   z-index: 50;
 }
 
 .dark-mode .primary-nav {
-  background: var(--surface-dark);
-  border-color: rgba(255, 255, 255, 0.08);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(226, 235, 255, 0.92));
+  border-color: rgba(21, 26, 51, 0.08);
+  box-shadow: 0 24px 50px rgba(43, 73, 178, 0.16);
 }
 
 .nav-divider {
@@ -264,19 +269,21 @@ button {
 .pill-button {
   padding: 0.45rem 1.2rem;
   border-radius: 999px;
-  border: 1px solid rgba(var(--foreground-rgb), 0.1);
-  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(83, 180, 255, 0.3);
+  background: linear-gradient(135deg, rgba(25, 33, 82, 0.9), rgba(74, 17, 120, 0.8));
   font-size: 0.75rem;
   letter-spacing: 0.3em;
   text-transform: uppercase;
   font-family: var(--font-space-mono), monospace;
-  color: rgba(var(--foreground-rgb), 0.8);
+  color: rgba(226, 241, 255, 0.85);
+  box-shadow: 0 12px 24px rgba(41, 240, 255, 0.22);
 }
 
 .dark-mode .pill-button {
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.75);
-  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(25, 32, 82, 0.08);
+  color: rgba(21, 26, 51, 0.75);
+  border-color: rgba(21, 26, 51, 0.1);
+  box-shadow: none;
 }
 
 .icon-button {
@@ -286,15 +293,17 @@ button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgba(var(--foreground-rgb), 0.12);
-  background: rgba(255, 255, 255, 0.65);
-  color: rgba(var(--foreground-rgb), 0.85);
+  border: 1px solid rgba(83, 180, 255, 0.28);
+  background: rgba(19, 24, 56, 0.82);
+  color: rgba(226, 241, 255, 0.9);
+  box-shadow: 0 10px 30px rgba(18, 24, 60, 0.45);
 }
 
 .dark-mode .icon-button {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.1);
-  color: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.85);
+  border-color: rgba(21, 26, 51, 0.1);
+  color: rgba(21, 26, 51, 0.85);
+  box-shadow: none;
 }
 
 .hero-badge {
@@ -303,17 +312,17 @@ button {
   gap: 0.65rem;
   padding: 0.55rem 1.4rem;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.65);
-  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(83, 180, 255, 0.3);
+  background: linear-gradient(135deg, rgba(25, 32, 82, 0.92), rgba(101, 48, 198, 0.72));
   font-size: 0.75rem;
   letter-spacing: 0.25em;
   text-transform: uppercase;
 }
 
 .dark-mode .hero-badge {
-  background: rgba(0, 0, 0, 0.55);
-  border-color: rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.85);
+  border-color: rgba(21, 26, 51, 0.12);
+  color: rgba(21, 26, 51, 0.85);
 }
 
 .badge-dot {
@@ -321,17 +330,17 @@ button {
   height: 8px;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
-  box-shadow: 0 0 12px rgba(255, 215, 92, 0.8);
+  box-shadow: 0 0 14px rgba(255, 71, 216, 0.85);
 }
 
 .gradient-text {
-  background: linear-gradient(135deg, rgba(var(--foreground-rgb), 1), rgba(var(--foreground-rgb), 0.65));
+  background: linear-gradient(135deg, rgba(255, 71, 216, 0.95), rgba(41, 240, 255, 0.85));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
 
 .dark-mode .gradient-text {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.65));
+  background: linear-gradient(135deg, rgba(21, 26, 51, 0.95), rgba(83, 180, 255, 0.7));
 }
 
 .text-muted {
@@ -369,10 +378,10 @@ button {
   justify-content: center;
   padding: 0.9rem 1.8rem;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(255, 214, 94, 0.95), rgba(255, 120, 87, 0.85));
-  color: #111;
-  font-weight: 600;
-  box-shadow: 0 18px 40px rgba(255, 214, 94, 0.25);
+  background: linear-gradient(135deg, rgba(255, 71, 216, 0.95), rgba(41, 240, 255, 0.95));
+  color: rgba(4, 6, 24, 0.95);
+  font-weight: 700;
+  box-shadow: 0 22px 50px rgba(41, 240, 255, 0.32);
 }
 
 .ghost-button {
@@ -381,13 +390,17 @@ button {
   justify-content: center;
   padding: 0.9rem 1.8rem;
   border-radius: 999px;
-  border: 1px solid rgba(var(--foreground-rgb), 0.2);
-  color: rgba(var(--foreground-rgb), 0.8);
+  border: 1px solid rgba(83, 180, 255, 0.35);
+  color: rgba(226, 241, 255, 0.75);
+  background: rgba(19, 24, 56, 0.6);
+  box-shadow: inset 0 0 20px rgba(41, 240, 255, 0.1);
 }
 
 .dark-mode .ghost-button {
-  border-color: rgba(255, 255, 255, 0.15);
-  color: rgba(255, 255, 255, 0.8);
+  border-color: rgba(21, 26, 51, 0.15);
+  color: rgba(21, 26, 51, 0.8);
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: none;
 }
 
 .ghost-link {
@@ -396,7 +409,7 @@ button {
   letter-spacing: 0.3em;
   text-transform: uppercase;
   font-family: var(--font-space-mono), monospace;
-  color: rgba(var(--foreground-rgb), 0.7);
+  color: rgba(226, 241, 255, 0.7);
 }
 
 .ghost-link::after {
@@ -418,22 +431,23 @@ button {
 }
 
 .dark-mode .ghost-link {
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(21, 26, 51, 0.7);
 }
 
 .glass-panel {
   position: relative;
-  background: var(--surface);
-  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: linear-gradient(145deg, rgba(20, 26, 66, 0.88), rgba(9, 12, 38, 0.9));
+  border: 1px solid rgba(83, 180, 255, 0.2);
   border-radius: 28px;
   backdrop-filter: blur(32px);
-  box-shadow: 0 28px 60px var(--shadow);
+  box-shadow: 0 32px 80px rgba(4, 6, 24, 0.6);
   overflow: hidden;
 }
 
 .dark-mode .glass-panel {
-  background: var(--surface-dark);
-  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.9);
+  border-color: rgba(21, 26, 51, 0.08);
+  box-shadow: 0 28px 60px rgba(43, 73, 178, 0.18);
 }
 
 .glass-panel::after {
@@ -441,7 +455,7 @@ button {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(83, 180, 255, 0.22);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.4s ease;
@@ -561,13 +575,15 @@ button {
 .insight-card {
   padding: 1.2rem 1.4rem;
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.45);
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: rgba(16, 20, 48, 0.75);
+  border: 1px solid rgba(83, 180, 255, 0.25);
+  box-shadow: inset 0 0 18px rgba(41, 240, 255, 0.12);
 }
 
 .dark-mode .insight-card {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.75);
+  border-color: rgba(21, 26, 51, 0.1);
+  box-shadow: none;
 }
 
 .highlight-text {
@@ -613,11 +629,11 @@ button {
 }
 
 .project-card:hover {
-  box-shadow: 0 32px 70px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 36px 90px rgba(41, 240, 255, 0.18);
 }
 
 .dark-mode .project-card:hover {
-  box-shadow: 0 32px 70px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 32px 70px rgba(43, 73, 178, 0.2);
 }
 
 .project-card-highlight {
@@ -674,17 +690,18 @@ button {
 .project-tag {
   padding: 0.45rem 1.1rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.55);
+  background: rgba(41, 240, 255, 0.12);
+  border: 1px solid rgba(83, 180, 255, 0.3);
   font-size: 0.75rem;
   letter-spacing: 0.25em;
   text-transform: uppercase;
   font-family: var(--font-space-mono), monospace;
-  color: rgba(var(--foreground-rgb), 0.7);
+  color: rgba(226, 241, 255, 0.75);
 }
 
 .dark-mode .project-tag {
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.7);
+  background: rgba(83, 180, 255, 0.12);
+  color: rgba(21, 26, 51, 0.75);
 }
 
 .project-impact {
@@ -692,11 +709,11 @@ button {
   letter-spacing: 0.3em;
   text-transform: uppercase;
   font-family: var(--font-space-mono), monospace;
-  color: rgba(var(--foreground-rgb), 0.55);
+  color: rgba(226, 241, 255, 0.7);
 }
 
 .dark-mode .project-impact {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(21, 26, 51, 0.55);
 }
 
 .timeline {
@@ -772,17 +789,19 @@ button {
 .timeline-tags span {
   padding: 0.35rem 0.9rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.5);
+  background: rgba(41, 240, 255, 0.15);
+  border: 1px solid rgba(83, 180, 255, 0.28);
   font-size: 0.75rem;
   letter-spacing: 0.25em;
   text-transform: uppercase;
   font-family: var(--font-space-mono), monospace;
-  color: rgba(var(--foreground-rgb), 0.65);
+  color: rgba(226, 241, 255, 0.75);
 }
 
 .dark-mode .timeline-tags span {
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.7);
+  background: rgba(83, 180, 255, 0.1);
+  border-color: rgba(21, 26, 51, 0.15);
+  color: rgba(21, 26, 51, 0.7);
 }
 
 .testimonial-card {
@@ -885,21 +904,21 @@ button {
   position: fixed;
   padding: 1rem 1.3rem;
   border-radius: 16px;
-  background: rgba(17, 17, 17, 0.88);
-  color: #fff;
+  background: linear-gradient(135deg, rgba(25, 32, 82, 0.95), rgba(41, 240, 255, 0.32));
+  color: rgba(226, 241, 255, 0.95);
   pointer-events: none;
   z-index: 70;
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 18px 44px rgba(4, 6, 24, 0.6);
   font-family: var(--font-space-mono), monospace;
 }
 
 .dark-mode .project-preview {
-  background: rgba(255, 255, 255, 0.12);
-  color: #fff;
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+  background: rgba(255, 255, 255, 0.9);
+  color: rgba(21, 26, 51, 0.9);
+  box-shadow: 0 18px 40px rgba(43, 73, 178, 0.2);
 }
 
 .keyboard-hint {
@@ -910,7 +929,7 @@ button {
   letter-spacing: 0.35em;
   text-transform: uppercase;
   font-family: var(--font-space-mono), monospace;
-  opacity: 0.5;
+  opacity: 0.65;
   z-index: 40;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,9 +10,9 @@ const spaceMono = Space_Mono({
 })
 
 export const metadata: Metadata = {
-  title: 'Bilhuda Pramana — Experience Architect',
+  title: 'Bilhuda Pramana — Gameverse Architect',
   description:
-    'Portfolio of Bilhuda Pramana, a UX designer crafting flagship digital experiences with emotion, rigor and measurable impact.'
+    'Step into the neon playground of Bilhuda Pramana — a game designer crafting cinematic sci-fi racers, co-op raids and unforgettable player journeys.'
 }
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,110 +3,110 @@
 import { useEffect, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 
-const WORDS = ['Designer', 'Thinker', 'Creator', 'Developer', 'UX Expert']
+const WORDS = ['Game Designer', 'World Builder', 'System Alchemist', 'Combat Scripter', 'Lore Weaver']
 
 const NAV_ITEMS = [
-  { label: 'Work', href: '#work' },
-  { label: 'Experience', href: '#about' },
-  { label: 'Kind Words', href: '#testimonials' },
+  { label: 'Games', href: '#games' },
+  { label: 'Quest Log', href: '#experience' },
+  { label: 'Player Chatter', href: '#community' },
   { label: 'Contact', href: '#contact' }
 ]
 
 const PROJECTS = [
   {
     id: 1,
-    title: 'E-commerce Flagship',
+    title: 'NEON DRIFT: HYPERLANE',
     description:
-      'Reimagined the purchase journey for a luxury fashion house with spatial storytelling and seamless motion micro-interactions.',
-    role: 'Lead Product Designer',
+      'Arcade roguelite racer set inside a synthwave metropolis. Procedural highways, reactive soundtrack and co-op rivalries keep the flow electric.',
+    role: 'Game Director & Systems Designer',
     year: '2024',
-    impact: '+28% conversion',
-    tags: ['Design Systems', 'Motion Language', 'A/B Testing'],
-    accent: 'linear-gradient(135deg, rgba(255,214,94,0.65), rgba(255,120,87,0.35))'
+    impact: '3.2M pilots',
+    tags: ['UE5', 'Procedural Tracks', 'Online Co-op'],
+    accent: 'linear-gradient(135deg, rgba(255,72,173,0.7), rgba(72,209,255,0.4))'
   },
   {
     id: 2,
-    title: 'Holistic Healthcare',
+    title: 'ASTRAL HAVEN',
     description:
-      'Crafted a calm and confident experience for a preventive-care platform balancing clinical data with human warmth.',
-    role: 'Principal UX Designer',
+      'Cozy sci-farm colony with day-night raids. Blend of tactile farming loops, base defense tactics and heartwarming NPC storylines.',
+    role: 'Creative Producer',
     year: '2023',
-    impact: '+41 NPS',
-    tags: ['Design Research', 'Accessibility', 'Service Blueprint'],
-    accent: 'linear-gradient(135deg, rgba(123,224,255,0.5), rgba(67,104,255,0.45))'
+    impact: '97% player sentiment',
+    tags: ['Hybrid Casual', 'Live Ops', 'Narrative Tools'],
+    accent: 'linear-gradient(135deg, rgba(135,255,158,0.45), rgba(44,232,224,0.45))'
   },
   {
     id: 3,
-    title: 'Financial Command Center',
+    title: 'CHROMA RAID',
     description:
-      'Designed a multi-device portfolio dashboard with adaptive density, cinematic transitions and real-time collaboration tools.',
-    role: 'Information Architecture',
+      'Stylized four-player heist set across dimension-shifting museums. Rhythm combat meets puzzle stealth with streamer-friendly tools.',
+    role: 'Multiplayer Experience Lead',
     year: '2023',
-    impact: 'x2 engagement',
-    tags: ['Data Visualization', 'Design Ops', 'Realtime Systems'],
-    accent: 'linear-gradient(135deg, rgba(168,255,120,0.45), rgba(46,196,182,0.45))'
+    impact: 'Top 5 on Twitch',
+    tags: ['Crossplay', 'Spectator Mode', 'Anti-Tilt UX'],
+    accent: 'linear-gradient(135deg, rgba(255,180,84,0.5), rgba(255,94,247,0.4))'
   },
   {
     id: 4,
-    title: 'Intelligent Mobility',
+    title: 'VOIDSONG: ECLIPSE',
     description:
-      'Built an intuitive companion app for electric vehicles with predictive routing, ambient gestures and adaptive audio cues.',
-    role: 'Experience Lead',
+      'Narrative rhythm shooter where spells are composed live. Features adaptive AI enemies and player-driven soundtrack remixes.',
+    role: 'Experience Architect',
     year: '2022',
-    impact: '-36% support tickets',
-    tags: ['Product Strategy', 'Voice & Gesture', 'Edge Cases'],
-    accent: 'linear-gradient(135deg, rgba(255,140,222,0.45), rgba(98,0,234,0.45))'
+    impact: 'Game Awards finalist',
+    tags: ['Music Systems', 'Accessibility', 'Haptics'],
+    accent: 'linear-gradient(135deg, rgba(112,123,255,0.55), rgba(255,105,120,0.4))'
   }
 ]
 
 const STATS = [
   {
-    id: 'experience',
-    value: '6+',
-    label: 'Years crafting flagship products',
-    description: 'From e-commerce to healthcare, leading end-to-end experience strategy.'
+    id: 'players',
+    value: '15M+',
+    label: 'Players traversed',
+    description: 'Across neon racers, cosmic raids and cozy life-sims with bite.'
   },
   {
-    id: 'launches',
-    value: '35',
-    label: 'High-impact launches',
-    description: 'Shipped experiences shaped around measurable outcomes and delight.'
+    id: 'prototypes',
+    value: '120',
+    label: 'Playable prototypes',
+    description: 'Rapid-fire experiments to nail feel, balance and UI readability.'
   },
   {
-    id: 'impact',
-    value: '120M+',
-    label: 'Users influenced',
-    description: 'Designing responsibly at scale for global, multi-platform ecosystems.'
+    id: 'ops',
+    value: '48h',
+    label: 'Average patch turnaround',
+    description: 'Live ops rituals keep every world balanced and buzzing.'
   }
 ]
 
 const EXPERIENCES = [
   {
     id: 1,
-    company: 'Nusantara Commerce',
-    role: 'Lead UX Designer',
+    company: 'Nebula Forge Studios',
+    role: 'Creative Director',
     period: '2022 — Present',
     summary:
-      'Guiding a multi-disciplinary product team to craft elevated retail journeys across Southeast Asia.',
-    focus: ['Design Strategy', 'Systems Thinking', 'Motion Direction']
+      'Leading a strike team shipping multiplatform co-op epics with Unreal Engine 5, bespoke tooling and a relentless playtest cadence.',
+    focus: ['UE5', 'Live Ops', 'Cinematic UX']
   },
   {
     id: 2,
-    company: 'Halo Health',
-    role: 'Senior Product Designer',
+    company: 'Solar Arcade Collective',
+    role: 'Lead Systems Designer',
     period: '2019 — 2022',
     summary:
-      'Built trust-driven patient experiences and unified clinician tooling with rigorous accessibility standards.',
-    focus: ['Inclusive Design', 'Service Design', 'Research Ops']
+      'Balanced economy loops and combat flows for award-winning indie hits while co-directing community tournament programs.',
+    focus: ['Systems Design', 'Multiplayer', 'Analytics']
   },
   {
     id: 3,
-    company: 'Freelance',
-    role: 'Experience Consultant',
-    period: '2017 — 2019',
+    company: 'Freelance Raids',
+    role: 'Prototype Mercenary',
+    period: '2016 — 2019',
     summary:
-      'Partnered with visionary founders to transform complex problems into signature product moments.',
-    focus: ['Brand Experience', 'Rapid Prototyping', 'Product Discovery']
+      'Partnered with dreamers to turn napkin sketches into jaw-dropping vertical slices that closed funding rounds.',
+    focus: ['Rapid Prototyping', 'Level Design', 'Unity']
   }
 ]
 
@@ -114,23 +114,23 @@ const TESTIMONIALS = [
   {
     id: 1,
     quote:
-      'Bilhuda brings an enviable calm to complex projects. Every interaction feels choreographed yet effortless for our customers.',
-    name: 'Amelia Hart',
-    title: 'VP of Product, Luminara'
+      'Bilhuda turned our scribbles into a living, breathing world. Every update lands like a community event and our players feel seen.',
+    name: 'Nova Liang',
+    title: 'CEO, Nebula Forge'
   },
   {
     id: 2,
     quote:
-      'A rare blend of systems thinking and poetic craft. Our flagship launch finally feels worthy of the brand we imagined.',
-    name: 'Kenji Nakamura',
-    title: 'Founder, Oru Mobility'
+      'The combat feel went from clunky to legendary in two sprints. Bilhuda is the raid leader every studio wants steering the ship.',
+    name: 'Rex Morales',
+    title: 'Game Director, Solar Arcade'
   },
   {
     id: 3,
     quote:
-      'From research to rollout, Bilhuda orchestrated the experience with empathy, precision and a sharp eye for detail.',
-    name: 'Sasha Patel',
-    title: 'Chief Experience Officer, Halo Health'
+      'Their prototypes are basically magic tricks — players gasp, investors lean in and suddenly we have a roadmap that sings.',
+    name: 'Ivy Loren',
+    title: 'Producer, Indie Megabooth'
   }
 ]
 
@@ -138,26 +138,26 @@ const FLOATING_ORBS = [
   {
     id: 1,
     size: 420,
-    top: '10%',
-    left: '8%',
+    top: '8%',
+    left: '6%',
     background:
-      'radial-gradient(circle at 30% 30%, rgba(255,214,94,0.55), transparent 60%)'
+      'radial-gradient(circle at 30% 30%, rgba(255,64,172,0.6), transparent 65%)'
   },
   {
     id: 2,
-    size: 520,
-    top: '55%',
-    left: '70%',
+    size: 560,
+    top: '52%',
+    left: '72%',
     background:
-      'radial-gradient(circle at 70% 40%, rgba(120,208,255,0.45), transparent 65%)'
+      'radial-gradient(circle at 70% 40%, rgba(60,245,255,0.5), transparent 68%)'
   },
   {
     id: 3,
-    size: 360,
-    top: '75%',
-    left: '15%',
+    size: 380,
+    top: '78%',
+    left: '18%',
     background:
-      'radial-gradient(circle at 50% 50%, rgba(255,140,222,0.45), transparent 60%)'
+      'radial-gradient(circle at 50% 50%, rgba(158,118,255,0.5), transparent 62%)'
   }
 ]
 
@@ -316,13 +316,13 @@ export default function Home() {
             href="#top"
             className="font-mono text-xs tracking-[0.3em] uppercase"
             whileHover={{ x: 4 }}
-            onMouseEnter={() => setCursorLabel('Home')}
+            onMouseEnter={() => setCursorLabel('Spawn point')}
             onMouseLeave={resetCursor}
           >
             Bilhuda
           </motion.a>
           <span className="nav-divider" />
-          <span className="text-xs uppercase opacity-60">Experience Architecture</span>
+          <span className="text-xs uppercase opacity-60">Gameverse Architect</span>
         </div>
         <div className="hidden md:flex items-center gap-8">
           {NAV_ITEMS.map((item) => (
@@ -344,17 +344,17 @@ export default function Home() {
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.96 }}
             onClick={toggleAboutModal}
-            onMouseEnter={() => setCursorLabel('About')}
+            onMouseEnter={() => setCursorLabel('Lore Terminal')}
             onMouseLeave={resetCursor}
           >
-            About
+            Lore
           </motion.button>
           <motion.button
             className="icon-button"
             onClick={() => setIsDarkMode((prev) => !prev)}
             whileHover={{ rotate: 10 }}
             whileTap={{ scale: 0.95 }}
-            onMouseEnter={() => setCursorLabel(isDarkMode ? 'Light' : 'Dark')}
+            onMouseEnter={() => setCursorLabel(isDarkMode ? 'Daycycle' : 'Nightcycle')}
             onMouseLeave={resetCursor}
             aria-label="Toggle theme"
           >
@@ -412,13 +412,16 @@ export default function Home() {
                 transition={{ delay: 0.2, duration: 0.6, ease: 'easeOut' }}
               >
                 <span className="badge-dot" />
-                Designing for emotion and clarity
+                Engineering neon-drenched adventures
               </motion.span>
               <motion.h1
                 className="text-6xl md:text-7xl xl:text-8xl font-bold leading-tight gradient-text"
                 style={{ transform: `translateY(${refinedScroll * -14}px)` }}
               >
                 BILHUDA PRAMANA
+                <span className="block text-2xl md:text-3xl font-normal tracking-[0.4em] mt-4">
+                  GAMEVERSE MODE
+                </span>
               </motion.h1>
               <motion.p
                 className="text-xl md:text-2xl max-w-2xl leading-relaxed text-muted"
@@ -426,30 +429,30 @@ export default function Home() {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.4, duration: 0.6, ease: 'easeOut' }}
               >
-                A UX <span className="word-morph">{WORDS[currentWordIndex]}</span> crafting holistic
-                ecosystems where technology disappears and the story takes center stage. Every
-                pixel, gesture and transition is considered for resonance.
+                A game <span className="word-morph">{WORDS[currentWordIndex]}</span> forging universes
+                where combat feels buttery, UI stays legible at warp speed and communities feel at
+                home. Every particle, sound cue and difficulty spike is tuned for maximum hype.
               </motion.p>
               <div className="flex flex-wrap gap-4">
                 <motion.a
-                  href="#work"
+                  href="#games"
                   className="cta-button"
                   whileHover={{ scale: 1.05, y: -4 }}
                   whileTap={{ scale: 0.96 }}
-                  onMouseEnter={() => setCursorLabel('Explore work')}
+                  onMouseEnter={() => setCursorLabel('Enter game vault')}
                   onMouseLeave={resetCursor}
                 >
-                  Explore the work
+                  Launch the worlds
                 </motion.a>
                 <motion.a
                   href="mailto:hello@bilhuda.com"
                   className="ghost-button"
                   whileHover={{ scale: 1.05, y: -4 }}
                   whileTap={{ scale: 0.96 }}
-                  onMouseEnter={() => setCursorLabel('Email me')}
+                  onMouseEnter={() => setCursorLabel('Send transmission')}
                   onMouseLeave={resetCursor}
                 >
-                  Start a project
+                  Drop a transmission
                 </motion.a>
               </div>
               <div className="grid gap-6 md:grid-cols-3">
@@ -481,17 +484,17 @@ export default function Home() {
               <div className="hero-grid" aria-hidden />
               <div className="relative space-y-8">
                 <div className="flex items-center justify-between">
-                  <p className="text-xs uppercase tracking-[0.4em] text-muted">Signature process</p>
+                  <p className="text-xs uppercase tracking-[0.4em] text-muted">Build pipeline</p>
                   <motion.span
                     className="accent-pill"
                     animate={{ opacity: [0.4, 1, 0.4] }}
                     transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
                   >
-                    Always evolving
+                    Patch 1.72 live
                   </motion.span>
                 </div>
                 <div className="space-y-5">
-                  {['Discover', 'Define', 'Design', 'Deliver'].map((step, index) => (
+                  {['Concept', 'Prototype', 'Playtest', 'Live Ops'].map((step, index) => (
                     <motion.div
                       key={step}
                       className="process-row"
@@ -513,12 +516,12 @@ export default function Home() {
                   <div className="insight-card">
                     <p className="text-xs uppercase tracking-[0.4em] text-muted">Currently</p>
                     <p className="text-base font-medium">
-                      Designing next-gen retail at <span className="highlight-text">Nusantara</span>
+                      Directing co-op chaos at <span className="highlight-text">Nebula Forge</span>
                     </p>
                   </div>
                   <div className="insight-card">
                     <p className="text-xs uppercase tracking-[0.4em] text-muted">Availability</p>
-                    <p className="text-base font-medium">Open for select collaborations</p>
+                    <p className="text-base font-medium">Accepting legendary party invites</p>
                   </div>
                 </div>
               </div>
@@ -527,7 +530,7 @@ export default function Home() {
         </motion.section>
 
         <motion.section
-          id="work"
+          id="games"
           className="container mx-auto px-4 space-y-12"
           initial={{ opacity: 0, y: 40 }}
           whileInView={{ opacity: 1, y: 0 }}
@@ -535,11 +538,11 @@ export default function Home() {
           transition={{ duration: 0.7, ease: 'easeOut' }}
         >
           <div className="section-heading">
-            <span className="section-eyebrow">Selected Work</span>
-            <h2 className="section-title">Flagship experiences crafted with intention</h2>
+            <span className="section-eyebrow">Featured Worlds</span>
+            <h2 className="section-title">Playtested experiences built for pure adrenaline</h2>
             <p className="section-description">
-              A collection of multidisciplinary stories where research, design systems and
-              motion converge to create signature product moments.
+              Each release blends cinematic spectacle with systems depth — crafted for teams,
+              streamers and solo explorers chasing a new obsession.
             </p>
           </div>
           <div className="grid gap-10 xl:grid-cols-2">
@@ -554,7 +557,7 @@ export default function Home() {
                 whileHover={{ y: -12, rotateX: 2, rotateY: -2 }}
                 onMouseEnter={() => {
                   setHoveredProject(project.id)
-                  setCursorLabel('View project')
+                  setCursorLabel('Inspect game')
                 }}
                 onMouseLeave={() => {
                   setHoveredProject(null)
@@ -577,7 +580,7 @@ export default function Home() {
                 <p className="project-description">{project.description}</p>
                 <div className="project-meta">
                   <span>{project.role}</span>
-                  <span>Experience leadership</span>
+                  <span>Party lead</span>
                 </div>
                 <div className="flex flex-wrap gap-3 pt-6">
                   {project.tags.map((tag) => (
@@ -598,7 +601,7 @@ export default function Home() {
         </motion.section>
 
         <motion.section
-          id="about"
+          id="experience"
           className="container mx-auto px-4 space-y-12"
           initial={{ opacity: 0, y: 40 }}
           whileInView={{ opacity: 1, y: 0 }}
@@ -606,11 +609,11 @@ export default function Home() {
           transition={{ duration: 0.7, ease: 'easeOut' }}
         >
           <div className="section-heading">
-            <span className="section-eyebrow">Experience</span>
-            <h2 className="section-title">Designing with empathy, rigor and poetry</h2>
+            <span className="section-eyebrow">Quest Log</span>
+            <h2 className="section-title">Leading squads through cinematic development cycles</h2>
             <p className="section-description">
-              A journey across industries shaping teams, systems and rituals that keep humans at
-              the heart of ambitious products.
+              From indie dream teams to AAA strike forces, I bridge creative chaos and live ops
+              discipline to keep every release humming.
             </p>
           </div>
           <div className="timeline">
@@ -645,7 +648,7 @@ export default function Home() {
         </motion.section>
 
         <motion.section
-          id="testimonials"
+          id="community"
           className="container mx-auto px-4 space-y-12"
           initial={{ opacity: 0, y: 40 }}
           whileInView={{ opacity: 1, y: 0 }}
@@ -653,11 +656,11 @@ export default function Home() {
           transition={{ duration: 0.7, ease: 'easeOut' }}
         >
           <div className="section-heading">
-            <span className="section-eyebrow">Kind Words</span>
-            <h2 className="section-title">What partners feel working together</h2>
+            <span className="section-eyebrow">Player Chatter</span>
+            <h2 className="section-title">Voices from the guilds and production floors</h2>
             <p className="section-description">
-              Partnerships rooted in trust, clarity and momentum. Here is how collaborators
-              describe the journey.
+              Developers, community leads and players reflecting on the raids, the sprints and the
+              unforgettable launch nights we shared.
             </p>
           </div>
           <div className="grid gap-6 md:grid-cols-3">
@@ -693,15 +696,15 @@ export default function Home() {
           <motion.div
             className="cta-card glass-panel"
             whileHover={{ scale: 1.01 }}
-            onMouseEnter={() => setCursorLabel('Collaborate')}
+            onMouseEnter={() => setCursorLabel('Open comms')}
             onMouseLeave={resetCursor}
           >
             <div className="space-y-6">
-              <span className="section-eyebrow">Let’s build the future</span>
-              <h2 className="section-title">Ready to craft a flagship experience together?</h2>
+              <span className="section-eyebrow">Open comms channel</span>
+              <h2 className="section-title">Assemble the next legendary drop together?</h2>
               <p className="section-description">
-                I partner with teams who value craft, measurable impact and long-term product
-                health. Let’s orchestrate the next chapter of your product.
+                Bring me your wildest mechanics, lore fragments or community dreams. I thrive on
+                co-piloting teams who crave spectacle, retention and heart.
               </p>
             </div>
             <div className="flex flex-col gap-4 md:items-end">
@@ -710,13 +713,13 @@ export default function Home() {
                 className="cta-button"
                 whileHover={{ scale: 1.05, y: -4 }}
                 whileTap={{ scale: 0.96 }}
-                onMouseEnter={() => setCursorLabel('Email me')}
+                onMouseEnter={() => setCursorLabel('Send transmission')}
                 onMouseLeave={resetCursor}
               >
                 hello@bilhuda.com
               </motion.a>
               <div className="flex gap-4">
-                {['LinkedIn', 'Twitter', 'Read.cv'].map((item) => (
+                {['Discord', 'Twitch', 'Itch.io'].map((item) => (
                   <motion.a
                     key={item}
                     href="#"
@@ -734,7 +737,7 @@ export default function Home() {
         </motion.section>
 
         <footer className="container mx-auto px-4 text-sm text-muted text-center pt-12">
-          © {new Date().getFullYear()} Bilhuda Pramana. Crafted with intention.
+          © {new Date().getFullYear()} Bilhuda Pramana. Respawned nightly in the gameverse.
         </footer>
       </main>
 
@@ -755,23 +758,27 @@ export default function Home() {
             >
               <div className="flex items-start justify-between gap-6">
                 <div className="space-y-4">
-                  <h2 className="text-3xl font-semibold">More about Bilhuda</h2>
+                  <h2 className="text-3xl font-semibold">Lore drop: Bilhuda</h2>
                   <p className="text-base leading-relaxed text-muted">
-                    I am a UX designer obsessed with the invisible choreography of great products.
-                    Psychology, sound design and architecture influence how I craft emotion into
-                    every interaction. Beyond the pixels, I facilitate rituals that keep teams
-                    aligned, curious and kind.
+                    I sculpt neon worlds that feel alive — from cinematic racers to lo-fi cozy
+                    sims. Years of systems design, animation tinkering and community rituals help
+                    me ship experiences that feel like Saturday-night raids with friends.
                   </p>
                   <p className="text-base leading-relaxed text-muted">
-                    Outside of design you will find me sketching cityscapes, collecting iconic
-                    chairs and exploring volcanic trails across Indonesia.
+                    When AFK I mod classic JRPGs, record ambient synth jams and host playtest
+                    nights in Jakarta’s indie arcade scene.
                   </p>
                   <div className="modal-skills">
-                    {['UX Design', 'Design Strategy', 'Motion Direction', 'Research Ops', 'Figma', 'Prototyping'].map(
-                      (skill) => (
-                        <span key={skill}>{skill}</span>
-                      )
-                    )}
+                    {[
+                      'Game Direction',
+                      'Combat Design',
+                      'Live Ops',
+                      'Sound Scripting',
+                      'Shader Art',
+                      'Community Rituals'
+                    ].map((skill) => (
+                      <span key={skill}>{skill}</span>
+                    ))}
                   </div>
                 </div>
                 <motion.button
@@ -779,9 +786,9 @@ export default function Home() {
                   onClick={toggleAboutModal}
                   whileHover={{ rotate: 90 }}
                   whileTap={{ scale: 0.9 }}
-                  onMouseEnter={() => setCursorLabel('Close')}
+                  onMouseEnter={() => setCursorLabel('Seal portal')}
                   onMouseLeave={resetCursor}
-                  aria-label="Close modal"
+                  aria-label="Close portal"
                 >
                   ×
                 </motion.button>
@@ -806,13 +813,13 @@ export default function Home() {
             exit={{ opacity: 0, scale: 0.9 }}
             transition={{ duration: 0.2, ease: 'easeOut' }}
           >
-            <span className="text-xs uppercase tracking-[0.4em] opacity-60">Impact</span>
+            <span className="text-xs uppercase tracking-[0.4em] opacity-60">Hype meter</span>
             <p className="text-sm font-semibold">{activeProject.impact}</p>
           </motion.div>
         )}
       </AnimatePresence>
 
-      <div className="keyboard-hint">Press Ctrl+D for dark mode · Ctrl+A for the story</div>
+      <div className="keyboard-hint">Press Ctrl+D for nightcycle · Ctrl+A for the lore drop</div>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- restyle the application around a neon gameverse theme with new copy, sections, and lore-driven interactions
- refresh global styling tokens with synthwave gradients, glassmorphism accents, and updated component treatments
- adjust site metadata to reflect the new game portfolio identity

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d538d7fbc883239fc616a67c7d7f75